### PR TITLE
mi-iconがクリックを透過する修正

### DIFF
--- a/src/components/icon/icon.css
+++ b/src/components/icon/icon.css
@@ -2,6 +2,7 @@
   display: inline-block;
   width: 1.28em;
   height: 1.28em;
+  pointer-events: none;
 }
 
 .icon {

--- a/tests/icon/icon.test.ts
+++ b/tests/icon/icon.test.ts
@@ -31,7 +31,7 @@ describe("mi-icon", () => {
     }
   });
 
-  test("pointer-eventsがnoneである", async () => {
+  test("クリックイベントが親要素に伝播する", async () => {
     document.body.innerHTML = `<mi-icon type="error-fill"></mi-icon>`;
     await customElements.whenDefined("mi-icon");
 

--- a/tests/icon/icon.test.ts
+++ b/tests/icon/icon.test.ts
@@ -31,6 +31,15 @@ describe("mi-icon", () => {
     }
   });
 
+  test("pointer-eventsがnoneである", async () => {
+    document.body.innerHTML = `<mi-icon type="error-fill"></mi-icon>`;
+    await customElements.whenDefined("mi-icon");
+
+    const icon = document.querySelector("mi-icon")!;
+    const style = getComputedStyle(icon);
+    expect(style.pointerEvents).toBe("none");
+  });
+
   test("type=error-fillである場合、アイコンの色を要素の外のcolorで変更できる", async () => {
     document.body.innerHTML = `<mi-icon type="error-fill"></mi-icon>`;
     await customElements.whenDefined("mi-icon");


### PR DESCRIPTION
アイコンのShadow DOM内SVGがクリックイベントのターゲットになり、
親要素のイベントハンドラが発火しない問題を修正。