### PR TITLE
feat(Chip): InputChipコンポーネントを追加

### DIFF
--- a/dist/custom-elements.json
+++ b/dist/custom-elements.json
@@ -121,6 +121,30 @@
         },
         {
           "kind": "js",
+          "name": "MiInputChip",
+          "declaration": {
+            "name": "MiInputChip",
+            "module": "./components/chip/mi-input-chip"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "InputChipItem",
+          "declaration": {
+            "name": "InputChipItem",
+            "module": "./components/chip/mi-input-chip-group"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "MiInputChipGroup",
+          "declaration": {
+            "name": "MiInputChipGroup",
+            "module": "./components/chip/mi-input-chip-group"
+          }
+        },
+        {
+          "kind": "js",
           "name": "FormDialogSize",
           "declaration": {
             "name": "FormDialogSize",
@@ -741,6 +765,676 @@
           "declaration": {
             "name": "SpAvatar",
             "module": "src/components/avatar/mi-avatar.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/checkbox/checkbox-text.css",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/checkbox/checkbox.css",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/checkbox/checkmark.css",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/checkbox/mi-checkbox-text.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MiCheckboxText",
+          "members": [
+            {
+              "kind": "field",
+              "name": "styles",
+              "static": true
+            },
+            {
+              "kind": "field",
+              "name": "formAssociated",
+              "type": {
+                "text": "boolean"
+              },
+              "static": true,
+              "default": "true"
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\""
+            },
+            {
+              "kind": "field",
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\""
+            },
+            {
+              "kind": "field",
+              "name": "checked",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "indeterminate",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "text",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\""
+            },
+            {
+              "kind": "field",
+              "name": "internals",
+              "type": {
+                "text": "ElementInternals"
+              },
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "updated",
+              "privacy": "protected",
+              "parameters": [
+                {
+                  "name": "changedProperties",
+                  "type": {
+                    "text": "Map<string, unknown>"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "handleChange",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "render"
+            }
+          ],
+          "events": [
+            {
+              "name": "change",
+              "type": {
+                "text": "CustomEvent"
+              }
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "summary": "テキスト付きチェックボックスです。",
+          "tagName": "mi-checkbox-text",
+          "customElement": true
+        },
+        {
+          "kind": "class",
+          "description": "",
+          "name": "SpCheckboxText",
+          "superclass": {
+            "name": "MiCheckboxText",
+            "module": "src/components/checkbox/mi-checkbox-text.ts"
+          },
+          "deprecated": "代わりに MiCheckboxText を使用してください",
+          "tagName": "sp-checkbox-text",
+          "customElement": true,
+          "members": [
+            {
+              "kind": "field",
+              "name": "styles",
+              "static": true,
+              "inheritedFrom": {
+                "name": "MiCheckboxText",
+                "module": "src/components/checkbox/mi-checkbox-text.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "formAssociated",
+              "type": {
+                "text": "boolean"
+              },
+              "static": true,
+              "default": "true",
+              "inheritedFrom": {
+                "name": "MiCheckboxText",
+                "module": "src/components/checkbox/mi-checkbox-text.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "inheritedFrom": {
+                "name": "MiCheckboxText",
+                "module": "src/components/checkbox/mi-checkbox-text.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "inheritedFrom": {
+                "name": "MiCheckboxText",
+                "module": "src/components/checkbox/mi-checkbox-text.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "checked",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "inheritedFrom": {
+                "name": "MiCheckboxText",
+                "module": "src/components/checkbox/mi-checkbox-text.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "indeterminate",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "inheritedFrom": {
+                "name": "MiCheckboxText",
+                "module": "src/components/checkbox/mi-checkbox-text.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "inheritedFrom": {
+                "name": "MiCheckboxText",
+                "module": "src/components/checkbox/mi-checkbox-text.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "text",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "inheritedFrom": {
+                "name": "MiCheckboxText",
+                "module": "src/components/checkbox/mi-checkbox-text.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "internals",
+              "type": {
+                "text": "ElementInternals"
+              },
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "MiCheckboxText",
+                "module": "src/components/checkbox/mi-checkbox-text.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "updated",
+              "privacy": "protected",
+              "parameters": [
+                {
+                  "name": "changedProperties",
+                  "type": {
+                    "text": "Map<string, unknown>"
+                  }
+                }
+              ],
+              "inheritedFrom": {
+                "name": "MiCheckboxText",
+                "module": "src/components/checkbox/mi-checkbox-text.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "handleChange",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ],
+              "inheritedFrom": {
+                "name": "MiCheckboxText",
+                "module": "src/components/checkbox/mi-checkbox-text.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "render",
+              "inheritedFrom": {
+                "name": "MiCheckboxText",
+                "module": "src/components/checkbox/mi-checkbox-text.ts"
+              }
+            }
+          ],
+          "events": [
+            {
+              "name": "change",
+              "type": {
+                "text": "CustomEvent"
+              },
+              "inheritedFrom": {
+                "name": "MiCheckboxText",
+                "module": "src/components/checkbox/mi-checkbox-text.ts"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "MiCheckboxText",
+          "declaration": {
+            "name": "MiCheckboxText",
+            "module": "src/components/checkbox/mi-checkbox-text.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "SpCheckboxText",
+          "declaration": {
+            "name": "SpCheckboxText",
+            "module": "src/components/checkbox/mi-checkbox-text.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "mi-checkbox-text",
+          "declaration": {
+            "name": "MiCheckboxText",
+            "module": "src/components/checkbox/mi-checkbox-text.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "sp-checkbox-text",
+          "declaration": {
+            "name": "SpCheckboxText",
+            "module": "src/components/checkbox/mi-checkbox-text.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/checkbox/mi-checkbox.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MiCheckbox",
+          "members": [
+            {
+              "kind": "field",
+              "name": "styles",
+              "static": true
+            },
+            {
+              "kind": "field",
+              "name": "formAssociated",
+              "type": {
+                "text": "boolean"
+              },
+              "static": true,
+              "default": "true"
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\""
+            },
+            {
+              "kind": "field",
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\""
+            },
+            {
+              "kind": "field",
+              "name": "checked",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "indeterminate",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "internals",
+              "type": {
+                "text": "ElementInternals"
+              },
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "updated",
+              "privacy": "protected",
+              "parameters": [
+                {
+                  "name": "changedProperties",
+                  "type": {
+                    "text": "Map<string, unknown>"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "handleChange",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "render"
+            }
+          ],
+          "events": [
+            {
+              "name": "change",
+              "type": {
+                "text": "CustomEvent"
+              }
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "summary": "チェックボックスです。",
+          "tagName": "mi-checkbox",
+          "customElement": true
+        },
+        {
+          "kind": "class",
+          "description": "",
+          "name": "SpCheckbox",
+          "superclass": {
+            "name": "MiCheckbox",
+            "module": "src/components/checkbox/mi-checkbox.ts"
+          },
+          "deprecated": "代わりに MiCheckbox を使用してください",
+          "tagName": "sp-checkbox",
+          "customElement": true,
+          "members": [
+            {
+              "kind": "field",
+              "name": "styles",
+              "static": true,
+              "inheritedFrom": {
+                "name": "MiCheckbox",
+                "module": "src/components/checkbox/mi-checkbox.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "formAssociated",
+              "type": {
+                "text": "boolean"
+              },
+              "static": true,
+              "default": "true",
+              "inheritedFrom": {
+                "name": "MiCheckbox",
+                "module": "src/components/checkbox/mi-checkbox.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "inheritedFrom": {
+                "name": "MiCheckbox",
+                "module": "src/components/checkbox/mi-checkbox.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "inheritedFrom": {
+                "name": "MiCheckbox",
+                "module": "src/components/checkbox/mi-checkbox.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "checked",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "inheritedFrom": {
+                "name": "MiCheckbox",
+                "module": "src/components/checkbox/mi-checkbox.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "indeterminate",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "inheritedFrom": {
+                "name": "MiCheckbox",
+                "module": "src/components/checkbox/mi-checkbox.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "inheritedFrom": {
+                "name": "MiCheckbox",
+                "module": "src/components/checkbox/mi-checkbox.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "internals",
+              "type": {
+                "text": "ElementInternals"
+              },
+              "privacy": "private",
+              "inheritedFrom": {
+                "name": "MiCheckbox",
+                "module": "src/components/checkbox/mi-checkbox.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "updated",
+              "privacy": "protected",
+              "parameters": [
+                {
+                  "name": "changedProperties",
+                  "type": {
+                    "text": "Map<string, unknown>"
+                  }
+                }
+              ],
+              "inheritedFrom": {
+                "name": "MiCheckbox",
+                "module": "src/components/checkbox/mi-checkbox.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "handleChange",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ],
+              "inheritedFrom": {
+                "name": "MiCheckbox",
+                "module": "src/components/checkbox/mi-checkbox.ts"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "render",
+              "inheritedFrom": {
+                "name": "MiCheckbox",
+                "module": "src/components/checkbox/mi-checkbox.ts"
+              }
+            }
+          ],
+          "events": [
+            {
+              "name": "change",
+              "type": {
+                "text": "CustomEvent"
+              },
+              "inheritedFrom": {
+                "name": "MiCheckbox",
+                "module": "src/components/checkbox/mi-checkbox.ts"
+              }
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "MiCheckbox",
+          "declaration": {
+            "name": "MiCheckbox",
+            "module": "src/components/checkbox/mi-checkbox.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "SpCheckbox",
+          "declaration": {
+            "name": "SpCheckbox",
+            "module": "src/components/checkbox/mi-checkbox.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "mi-checkbox",
+          "declaration": {
+            "name": "MiCheckbox",
+            "module": "src/components/checkbox/mi-checkbox.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "sp-checkbox",
+          "declaration": {
+            "name": "SpCheckbox",
+            "module": "src/components/checkbox/mi-checkbox.ts"
           }
         }
       ]
@@ -4032,366 +4726,54 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/checkbox/checkbox-text.css",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/checkbox/checkbox.css",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/checkbox/checkmark.css",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/checkbox/mi-checkbox-text.ts",
+      "path": "src/components/chip/input-chip-group.styles.ts",
       "declarations": [
         {
-          "kind": "class",
-          "description": "",
-          "name": "MiCheckboxText",
-          "members": [
-            {
-              "kind": "field",
-              "name": "styles",
-              "static": true
-            },
-            {
-              "kind": "field",
-              "name": "formAssociated",
-              "type": {
-                "text": "boolean"
-              },
-              "static": true,
-              "default": "true"
-            },
-            {
-              "kind": "field",
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\""
-            },
-            {
-              "kind": "field",
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\""
-            },
-            {
-              "kind": "field",
-              "name": "checked",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false"
-            },
-            {
-              "kind": "field",
-              "name": "indeterminate",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false"
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false"
-            },
-            {
-              "kind": "field",
-              "name": "text",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\""
-            },
-            {
-              "kind": "field",
-              "name": "internals",
-              "type": {
-                "text": "ElementInternals"
-              },
-              "privacy": "private"
-            },
-            {
-              "kind": "method",
-              "name": "updated",
-              "privacy": "protected",
-              "parameters": [
-                {
-                  "name": "changedProperties",
-                  "type": {
-                    "text": "Map<string, unknown>"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "handleChange",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "event",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "render"
-            }
-          ],
-          "events": [
-            {
-              "name": "change",
-              "type": {
-                "text": "CustomEvent"
-              }
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "summary": "テキスト付きチェックボックスです。",
-          "tagName": "mi-checkbox-text",
-          "customElement": true
-        },
-        {
-          "kind": "class",
-          "description": "",
-          "name": "SpCheckboxText",
-          "superclass": {
-            "name": "MiCheckboxText",
-            "module": "src/components/checkbox/mi-checkbox-text.ts"
-          },
-          "deprecated": "代わりに MiCheckboxText を使用してください",
-          "tagName": "sp-checkbox-text",
-          "customElement": true,
-          "members": [
-            {
-              "kind": "field",
-              "name": "styles",
-              "static": true,
-              "inheritedFrom": {
-                "name": "MiCheckboxText",
-                "module": "src/components/checkbox/mi-checkbox-text.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "formAssociated",
-              "type": {
-                "text": "boolean"
-              },
-              "static": true,
-              "default": "true",
-              "inheritedFrom": {
-                "name": "MiCheckboxText",
-                "module": "src/components/checkbox/mi-checkbox-text.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\"",
-              "inheritedFrom": {
-                "name": "MiCheckboxText",
-                "module": "src/components/checkbox/mi-checkbox-text.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\"",
-              "inheritedFrom": {
-                "name": "MiCheckboxText",
-                "module": "src/components/checkbox/mi-checkbox-text.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "checked",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "inheritedFrom": {
-                "name": "MiCheckboxText",
-                "module": "src/components/checkbox/mi-checkbox-text.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "indeterminate",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "inheritedFrom": {
-                "name": "MiCheckboxText",
-                "module": "src/components/checkbox/mi-checkbox-text.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "inheritedFrom": {
-                "name": "MiCheckboxText",
-                "module": "src/components/checkbox/mi-checkbox-text.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "text",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\"",
-              "inheritedFrom": {
-                "name": "MiCheckboxText",
-                "module": "src/components/checkbox/mi-checkbox-text.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "internals",
-              "type": {
-                "text": "ElementInternals"
-              },
-              "privacy": "private",
-              "inheritedFrom": {
-                "name": "MiCheckboxText",
-                "module": "src/components/checkbox/mi-checkbox-text.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "updated",
-              "privacy": "protected",
-              "parameters": [
-                {
-                  "name": "changedProperties",
-                  "type": {
-                    "text": "Map<string, unknown>"
-                  }
-                }
-              ],
-              "inheritedFrom": {
-                "name": "MiCheckboxText",
-                "module": "src/components/checkbox/mi-checkbox-text.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "handleChange",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "event",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ],
-              "inheritedFrom": {
-                "name": "MiCheckboxText",
-                "module": "src/components/checkbox/mi-checkbox-text.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "render",
-              "inheritedFrom": {
-                "name": "MiCheckboxText",
-                "module": "src/components/checkbox/mi-checkbox-text.ts"
-              }
-            }
-          ],
-          "events": [
-            {
-              "name": "change",
-              "type": {
-                "text": "CustomEvent"
-              },
-              "inheritedFrom": {
-                "name": "MiCheckboxText",
-                "module": "src/components/checkbox/mi-checkbox-text.ts"
-              }
-            }
-          ]
+          "kind": "variable",
+          "name": "inputChipGroupStyles",
+          "default": "css` :host { display: block; } .container { display: flex; flex-wrap: wrap; gap: 4px; align-items: flex-start; align-content: flex-start; } .item { flex: 0 1 auto; max-width: 100%; min-width: 0; } `"
         }
       ],
       "exports": [
         {
           "kind": "js",
-          "name": "MiCheckboxText",
+          "name": "inputChipGroupStyles",
           "declaration": {
-            "name": "MiCheckboxText",
-            "module": "src/components/checkbox/mi-checkbox-text.ts"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "SpCheckboxText",
-          "declaration": {
-            "name": "SpCheckboxText",
-            "module": "src/components/checkbox/mi-checkbox-text.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "mi-checkbox-text",
-          "declaration": {
-            "name": "MiCheckboxText",
-            "module": "src/components/checkbox/mi-checkbox-text.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "sp-checkbox-text",
-          "declaration": {
-            "name": "SpCheckboxText",
-            "module": "src/components/checkbox/mi-checkbox-text.ts"
+            "name": "inputChipGroupStyles",
+            "module": "src/components/chip/input-chip-group.styles.ts"
           }
         }
       ]
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/checkbox/mi-checkbox.ts",
+      "path": "src/components/chip/input-chip.styles.ts",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "inputChipStyles",
+          "default": "css` :host { display: inline-block; max-width: 100%; min-width: 0; } .chip { display: inline-flex; align-items: center; gap: 2px; max-width: 100%; padding-inline-start: var(--spacing-large, 12px); padding-inline-end: var(--spacing-small, 4px); padding-block: 2px; min-block-size: 28px; border-radius: 9999px; background-color: #e8edff; box-sizing: border-box; } .label { font-size: 12px; font-weight: normal; line-height: 1.5; letter-spacing: 0.12px; color: var(--text-regular-default, rgba(0, 0, 0, 0.84)); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; } @media (max-width: 720px) { .chip { min-block-size: 32px; } .label { font-size: var(--font-scale-40, 14px); letter-spacing: 0.14px; } } `"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "inputChipStyles",
+          "declaration": {
+            "name": "inputChipStyles",
+            "module": "src/components/chip/input-chip.styles.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/chip/mi-input-chip-group.ts",
       "declarations": [
         {
           "kind": "class",
           "description": "",
-          "name": "MiCheckbox",
+          "name": "MiInputChipGroup",
           "members": [
             {
               "kind": "field",
@@ -4400,302 +4782,134 @@
             },
             {
               "kind": "field",
-              "name": "formAssociated",
+              "name": "items",
               "type": {
-                "text": "boolean"
+                "text": "InputChipItem[]"
               },
-              "static": true,
-              "default": "true"
-            },
-            {
-              "kind": "field",
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\""
-            },
-            {
-              "kind": "field",
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\""
-            },
-            {
-              "kind": "field",
-              "name": "checked",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false"
-            },
-            {
-              "kind": "field",
-              "name": "indeterminate",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false"
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false"
-            },
-            {
-              "kind": "field",
-              "name": "internals",
-              "type": {
-                "text": "ElementInternals"
-              },
-              "privacy": "private"
-            },
-            {
-              "kind": "method",
-              "name": "updated",
-              "privacy": "protected",
-              "parameters": [
-                {
-                  "name": "changedProperties",
-                  "type": {
-                    "text": "Map<string, unknown>"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "handleChange",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "event",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ]
+              "default": "[]",
+              "description": "表示する Chip アイテムの配列。"
             },
             {
               "kind": "method",
               "name": "render"
+            },
+            {
+              "kind": "method",
+              "name": "handleRemove",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "id",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
             }
           ],
           "events": [
             {
-              "name": "change",
+              "name": "remove",
               "type": {
                 "text": "CustomEvent"
-              }
+              },
+              "description": "Chip の削除ボタンがクリックされたときに発火します。detail に削除対象の id を含みます。"
             }
           ],
           "superclass": {
             "name": "LitElement",
             "package": "lit"
           },
-          "summary": "チェックボックスです。",
-          "tagName": "mi-checkbox",
+          "summary": "複数の mi-input-chip をまとめて表示するグループコンポーネントです。\nユーザーが入力した内容を要素ごとに整理して表示し、個別に削除できます。",
+          "tagName": "mi-input-chip-group",
           "customElement": true
-        },
-        {
-          "kind": "class",
-          "description": "",
-          "name": "SpCheckbox",
-          "superclass": {
-            "name": "MiCheckbox",
-            "module": "src/components/checkbox/mi-checkbox.ts"
-          },
-          "deprecated": "代わりに MiCheckbox を使用してください",
-          "tagName": "sp-checkbox",
-          "customElement": true,
-          "members": [
-            {
-              "kind": "field",
-              "name": "styles",
-              "static": true,
-              "inheritedFrom": {
-                "name": "MiCheckbox",
-                "module": "src/components/checkbox/mi-checkbox.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "formAssociated",
-              "type": {
-                "text": "boolean"
-              },
-              "static": true,
-              "default": "true",
-              "inheritedFrom": {
-                "name": "MiCheckbox",
-                "module": "src/components/checkbox/mi-checkbox.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\"",
-              "inheritedFrom": {
-                "name": "MiCheckbox",
-                "module": "src/components/checkbox/mi-checkbox.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\"",
-              "inheritedFrom": {
-                "name": "MiCheckbox",
-                "module": "src/components/checkbox/mi-checkbox.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "checked",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "inheritedFrom": {
-                "name": "MiCheckbox",
-                "module": "src/components/checkbox/mi-checkbox.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "indeterminate",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "inheritedFrom": {
-                "name": "MiCheckbox",
-                "module": "src/components/checkbox/mi-checkbox.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "inheritedFrom": {
-                "name": "MiCheckbox",
-                "module": "src/components/checkbox/mi-checkbox.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "internals",
-              "type": {
-                "text": "ElementInternals"
-              },
-              "privacy": "private",
-              "inheritedFrom": {
-                "name": "MiCheckbox",
-                "module": "src/components/checkbox/mi-checkbox.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "updated",
-              "privacy": "protected",
-              "parameters": [
-                {
-                  "name": "changedProperties",
-                  "type": {
-                    "text": "Map<string, unknown>"
-                  }
-                }
-              ],
-              "inheritedFrom": {
-                "name": "MiCheckbox",
-                "module": "src/components/checkbox/mi-checkbox.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "handleChange",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "event",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ],
-              "inheritedFrom": {
-                "name": "MiCheckbox",
-                "module": "src/components/checkbox/mi-checkbox.ts"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "render",
-              "inheritedFrom": {
-                "name": "MiCheckbox",
-                "module": "src/components/checkbox/mi-checkbox.ts"
-              }
-            }
-          ],
-          "events": [
-            {
-              "name": "change",
-              "type": {
-                "text": "CustomEvent"
-              },
-              "inheritedFrom": {
-                "name": "MiCheckbox",
-                "module": "src/components/checkbox/mi-checkbox.ts"
-              }
-            }
-          ]
         }
       ],
       "exports": [
         {
           "kind": "js",
-          "name": "MiCheckbox",
+          "name": "MiInputChipGroup",
           "declaration": {
-            "name": "MiCheckbox",
-            "module": "src/components/checkbox/mi-checkbox.ts"
+            "name": "MiInputChipGroup",
+            "module": "src/components/chip/mi-input-chip-group.ts"
           }
         },
+        {
+          "kind": "custom-element-definition",
+          "name": "mi-input-chip-group",
+          "declaration": {
+            "name": "MiInputChipGroup",
+            "module": "src/components/chip/mi-input-chip-group.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/chip/mi-input-chip.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "MiInputChip",
+          "members": [
+            {
+              "kind": "field",
+              "name": "styles",
+              "static": true
+            },
+            {
+              "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\"",
+              "description": "Chip に表示するテキスト。"
+            },
+            {
+              "kind": "method",
+              "name": "render"
+            },
+            {
+              "kind": "method",
+              "name": "handleRemove",
+              "privacy": "private"
+            }
+          ],
+          "events": [
+            {
+              "name": "remove",
+              "type": {
+                "text": "CustomEvent"
+              },
+              "description": "削除ボタンがクリックされたときに発火します。"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "summary": "ユーザーが入力した内容を要素ごとに整理して表示するための Chip コンポーネントです。\n企業やユーザーアカウントの入力などで利用され、×ボタンで入力内容を削除できます。",
+          "tagName": "mi-input-chip",
+          "customElement": true
+        }
+      ],
+      "exports": [
         {
           "kind": "js",
-          "name": "SpCheckbox",
+          "name": "MiInputChip",
           "declaration": {
-            "name": "SpCheckbox",
-            "module": "src/components/checkbox/mi-checkbox.ts"
+            "name": "MiInputChip",
+            "module": "src/components/chip/mi-input-chip.ts"
           }
         },
         {
           "kind": "custom-element-definition",
-          "name": "mi-checkbox",
+          "name": "mi-input-chip",
           "declaration": {
-            "name": "MiCheckbox",
-            "module": "src/components/checkbox/mi-checkbox.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "sp-checkbox",
-          "declaration": {
-            "name": "SpCheckbox",
-            "module": "src/components/checkbox/mi-checkbox.ts"
+            "name": "MiInputChip",
+            "module": "src/components/chip/mi-input-chip.ts"
           }
         }
       ]

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -157,6 +157,11 @@ export declare type InformationDialogSize = (typeof informationDialogSizes)[numb
 
 export declare const informationDialogSizes: readonly ["small", "medium"];
 
+export declare interface InputChipItem {
+    id: string;
+    label: string;
+}
+
 /**
  * Action Dialog
  *
@@ -431,6 +436,46 @@ export declare class MiInlineNotification extends LitElement {
     type: Type;
     static styles: CSSResult[];
     render(): TemplateResult<1>;
+}
+
+/**
+ * @summary ユーザーが入力した内容を要素ごとに整理して表示するための Chip コンポーネントです。
+ * 企業やユーザーアカウントの入力などで利用され、×ボタンで入力内容を削除できます。
+ *
+ * @example
+ * ```html
+ * <mi-input-chip label="Apple"></mi-input-chip>
+ * ```
+ *
+ * @fires remove - 削除ボタンがクリックされたときに発火します。
+ */
+export declare class MiInputChip extends LitElement {
+    static styles: CSSResult[];
+    /** Chip に表示するテキスト。 */
+    label: string;
+    render(): TemplateResult<1>;
+    private handleRemove;
+}
+
+/**
+ * @summary 複数の mi-input-chip をまとめて表示するグループコンポーネントです。
+ * ユーザーが入力した内容を要素ごとに整理して表示し、個別に削除できます。
+ *
+ * @example
+ * ```html
+ * <mi-input-chip-group
+ *   aria-label="選択された項目"
+ * ></mi-input-chip-group>
+ * ```
+ *
+ * @fires remove - Chip の削除ボタンがクリックされたときに発火します。detail に削除対象の id を含みます。
+ */
+export declare class MiInputChipGroup extends LitElement {
+    static styles: CSSResult[];
+    /** 表示する Chip アイテムの配列。 */
+    items: InputChipItem[];
+    render(): TemplateResult<1>;
+    private handleRemove;
 }
 
 /**
@@ -830,6 +875,21 @@ export { }
 
 declare global {
     interface HTMLElementTagNameMap {
+        "mi-icon-button": MiIconButton;
+    }
+}
+
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "mi-label-unit": MiLabelUnit;
+        "sp-label-unit": SpLabelUnit;
+    }
+}
+
+
+declare global {
+    interface HTMLElementTagNameMap {
         "mi-tooltip": MiTooltip;
     }
 }
@@ -837,8 +897,14 @@ declare global {
 
 declare global {
     interface HTMLElementTagNameMap {
-        "mi-avatar": MiAvatar;
-        "sp-avatar": SpAvatar;
+        "mi-snackbar": MiSnackbar;
+    }
+}
+
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "mi-input-chip-group": MiInputChipGroup;
     }
 }
 
@@ -852,14 +918,39 @@ declare global {
 
 declare global {
     interface HTMLElementTagNameMap {
-        "mi-danger-button": MiDangerButton;
+        "mi-snackbar-viewport": MiSnackbarViewport;
     }
 }
 
 
 declare global {
     interface HTMLElementTagNameMap {
-        "mi-icon-button": MiIconButton;
+        "mi-checkbox-text": MiCheckboxText;
+        "sp-checkbox-text": SpCheckboxText;
+    }
+}
+
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "mi-text-field-error-text": MiTextFieldErrorText;
+        "sp-text-field-error-text": SpTextFieldErrorText;
+    }
+}
+
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "mi-control-menu": MiControlMenu;
+        "sp-control-menu": SpControlMenu;
+    }
+}
+
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "mi-text-field": MiTextField;
+        "sp-text-field": SpTextField;
     }
 }
 
@@ -875,47 +966,7 @@ declare global {
 
 declare global {
     interface HTMLElementTagNameMap {
-        "mi-checkbox": MiCheckbox;
-        "sp-checkbox": SpCheckbox;
-    }
-}
-
-
-declare global {
-    interface HTMLElementTagNameMap {
-        "mi-checkbox-text": MiCheckboxText;
-        "sp-checkbox-text": SpCheckboxText;
-    }
-}
-
-
-declare global {
-    interface HTMLElementTagNameMap {
-        "mi-icon": MiIcon;
-        "sp-icon": SpIcon;
-    }
-}
-
-
-declare global {
-    interface HTMLElementTagNameMap {
         "mi-icon-color": MiIconColor;
-    }
-}
-
-
-declare global {
-    interface HTMLElementTagNameMap {
-        "mi-floating-button": MiFloatingButton;
-        "sp-floating-button": SpFloatingButton;
-    }
-}
-
-
-declare global {
-    interface HTMLElementTagNameMap {
-        "mi-label-unit": MiLabelUnit;
-        "sp-label-unit": SpLabelUnit;
     }
 }
 
@@ -930,54 +981,8 @@ declare global {
 
 declare global {
     interface HTMLElementTagNameMap {
-        "mi-control-menu": MiControlMenu;
-        "sp-control-menu": SpControlMenu;
-    }
-}
-
-
-declare global {
-    interface HTMLElementTagNameMap {
-        "mi-control-menu-item": MiControlMenuItem;
-        "sp-control-menu-item": SpControlMenuItem;
-    }
-}
-
-
-declare global {
-    interface HTMLElementTagNameMap {
-        "mi-radio-button-text": MiRadioButtonText;
-        "sp-radio-button-text": SpRadioButtonText;
-    }
-}
-
-
-declare global {
-    interface HTMLElementTagNameMap {
-        "mi-snackbar": MiSnackbar;
-    }
-}
-
-
-declare global {
-    interface HTMLElementTagNameMap {
-        "mi-snackbar-viewport": MiSnackbarViewport;
-    }
-}
-
-
-declare global {
-    interface HTMLElementTagNameMap {
-        "mi-text-field": MiTextField;
-        "sp-text-field": SpTextField;
-    }
-}
-
-
-declare global {
-    interface HTMLElementTagNameMap {
-        "mi-text-field-error-text": MiTextFieldErrorText;
-        "sp-text-field-error-text": SpTextFieldErrorText;
+        "mi-floating-button": MiFloatingButton;
+        "sp-floating-button": SpFloatingButton;
     }
 }
 
@@ -992,21 +997,54 @@ declare global {
 
 declare global {
     interface HTMLElementTagNameMap {
-        "mi-action-dialog": MiActionDialog;
+        "mi-icon": MiIcon;
+        "sp-icon": SpIcon;
     }
 }
 
 
 declare global {
     interface HTMLElementTagNameMap {
-        "mi-form-dialog": MiFormDialog;
+        "mi-avatar": MiAvatar;
+        "sp-avatar": SpAvatar;
     }
 }
 
 
 declare global {
     interface HTMLElementTagNameMap {
-        "mi-information-dialog": MiInformationDialog;
+        "mi-radio-button-text": MiRadioButtonText;
+        "sp-radio-button-text": SpRadioButtonText;
+    }
+}
+
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "mi-danger-button": MiDangerButton;
+    }
+}
+
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "mi-control-menu-item": MiControlMenuItem;
+        "sp-control-menu-item": SpControlMenuItem;
+    }
+}
+
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "mi-checkbox": MiCheckbox;
+        "sp-checkbox": SpCheckbox;
+    }
+}
+
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "mi-input-chip": MiInputChip;
     }
 }
 
@@ -1029,5 +1067,26 @@ declare global {
 declare global {
     interface HTMLElementTagNameMap {
         "mi-speeda-logo": MiSpeedaLogo;
+    }
+}
+
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "mi-form-dialog": MiFormDialog;
+    }
+}
+
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "mi-action-dialog": MiActionDialog;
+    }
+}
+
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "mi-information-dialog": MiInformationDialog;
     }
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -254,84 +254,84 @@ var S = class extends HTMLElement {
 S.elementStyles = [], S.shadowRootOptions = { mode: "open" }, S[y("elementProperties")] = /* @__PURE__ */ new Map(), S[y("finalized")] = /* @__PURE__ */ new Map(), v?.({ ReactiveElement: S }), (h.reactiveElementVersions ??= []).push("2.1.2");
 //#endregion
 //#region node_modules/lit-html/lit-html.js
-var C = globalThis, w = (e) => e, te = C.trustedTypes, ne = te ? te.createPolicy("lit-html", { createHTML: (e) => e }) : void 0, re = "$lit$", T = `lit$${Math.random().toFixed(9).slice(2)}$`, ie = "?" + T, ae = `<${ie}>`, E = document, oe = () => E.createComment(""), se = (e) => e === null || typeof e != "object" && typeof e != "function", ce = Array.isArray, le = (e) => ce(e) || typeof e?.[Symbol.iterator] == "function", ue = "[ 	\n\f\r]", de = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, fe = /-->/g, pe = />/g, D = RegExp(`>|${ue}(?:([^\\s"'>=/]+)(${ue}*=${ue}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`, "g"), me = /'/g, he = /"/g, ge = /^(?:script|style|textarea|title)$/i, O = ((e) => (t, ...n) => ({
+var te = globalThis, C = (e) => e, ne = te.trustedTypes, re = ne ? ne.createPolicy("lit-html", { createHTML: (e) => e }) : void 0, ie = "$lit$", w = `lit$${Math.random().toFixed(9).slice(2)}$`, ae = "?" + w, oe = `<${ae}>`, T = document, se = () => T.createComment(""), ce = (e) => e === null || typeof e != "object" && typeof e != "function", le = Array.isArray, ue = (e) => le(e) || typeof e?.[Symbol.iterator] == "function", de = "[ 	\n\f\r]", fe = /<(?:(!--|\/[^a-zA-Z])|(\/?[a-zA-Z][^>\s]*)|(\/?$))/g, pe = /-->/g, me = />/g, E = RegExp(`>|${de}(?:([^\\s"'>=/]+)(${de}*=${de}*(?:[^ \t\n\f\r"'\`<>=]|("|')|))|$)`, "g"), he = /'/g, ge = /"/g, _e = /^(?:script|style|textarea|title)$/i, D = ((e) => (t, ...n) => ({
 	_$litType$: e,
 	strings: t,
 	values: n
-}))(1), k = Symbol.for("lit-noChange"), A = Symbol.for("lit-nothing"), _e = /* @__PURE__ */ new WeakMap(), j = E.createTreeWalker(E, 129);
-function ve(e, t) {
-	if (!ce(e) || !e.hasOwnProperty("raw")) throw Error("invalid template strings array");
-	return ne === void 0 ? t : ne.createHTML(t);
+}))(1), O = Symbol.for("lit-noChange"), k = Symbol.for("lit-nothing"), ve = /* @__PURE__ */ new WeakMap(), ye = T.createTreeWalker(T, 129);
+function be(e, t) {
+	if (!le(e) || !e.hasOwnProperty("raw")) throw Error("invalid template strings array");
+	return re === void 0 ? t : re.createHTML(t);
 }
-var ye = (e, t) => {
-	let n = e.length - 1, r = [], i, a = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", o = de;
+var xe = (e, t) => {
+	let n = e.length - 1, r = [], i, a = t === 2 ? "<svg>" : t === 3 ? "<math>" : "", o = fe;
 	for (let t = 0; t < n; t++) {
 		let n = e[t], s, c, l = -1, u = 0;
-		for (; u < n.length && (o.lastIndex = u, c = o.exec(n), c !== null);) u = o.lastIndex, o === de ? c[1] === "!--" ? o = fe : c[1] === void 0 ? c[2] === void 0 ? c[3] !== void 0 && (o = D) : (ge.test(c[2]) && (i = RegExp("</" + c[2], "g")), o = D) : o = pe : o === D ? c[0] === ">" ? (o = i ?? de, l = -1) : c[1] === void 0 ? l = -2 : (l = o.lastIndex - c[2].length, s = c[1], o = c[3] === void 0 ? D : c[3] === "\"" ? he : me) : o === he || o === me ? o = D : o === fe || o === pe ? o = de : (o = D, i = void 0);
-		let d = o === D && e[t + 1].startsWith("/>") ? " " : "";
-		a += o === de ? n + ae : l >= 0 ? (r.push(s), n.slice(0, l) + re + n.slice(l) + T + d) : n + T + (l === -2 ? t : d);
+		for (; u < n.length && (o.lastIndex = u, c = o.exec(n), c !== null);) u = o.lastIndex, o === fe ? c[1] === "!--" ? o = pe : c[1] === void 0 ? c[2] === void 0 ? c[3] !== void 0 && (o = E) : (_e.test(c[2]) && (i = RegExp("</" + c[2], "g")), o = E) : o = me : o === E ? c[0] === ">" ? (o = i ?? fe, l = -1) : c[1] === void 0 ? l = -2 : (l = o.lastIndex - c[2].length, s = c[1], o = c[3] === void 0 ? E : c[3] === "\"" ? ge : he) : o === ge || o === he ? o = E : o === pe || o === me ? o = fe : (o = E, i = void 0);
+		let d = o === E && e[t + 1].startsWith("/>") ? " " : "";
+		a += o === fe ? n + oe : l >= 0 ? (r.push(s), n.slice(0, l) + ie + n.slice(l) + w + d) : n + w + (l === -2 ? t : d);
 	}
-	return [ve(e, a + (e[n] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), r];
-}, be = class e {
+	return [be(e, a + (e[n] || "<?>") + (t === 2 ? "</svg>" : t === 3 ? "</math>" : "")), r];
+}, Se = class e {
 	constructor({ strings: t, _$litType$: n }, r) {
 		let i;
 		this.parts = [];
-		let a = 0, o = 0, s = t.length - 1, c = this.parts, [l, u] = ye(t, n);
-		if (this.el = e.createElement(l, r), j.currentNode = this.el.content, n === 2 || n === 3) {
+		let a = 0, o = 0, s = t.length - 1, c = this.parts, [l, u] = xe(t, n);
+		if (this.el = e.createElement(l, r), ye.currentNode = this.el.content, n === 2 || n === 3) {
 			let e = this.el.content.firstChild;
 			e.replaceWith(...e.childNodes);
 		}
-		for (; (i = j.nextNode()) !== null && c.length < s;) {
+		for (; (i = ye.nextNode()) !== null && c.length < s;) {
 			if (i.nodeType === 1) {
-				if (i.hasAttributes()) for (let e of i.getAttributeNames()) if (e.endsWith(re)) {
-					let t = u[o++], n = i.getAttribute(e).split(T), r = /([.?@])?(.*)/.exec(t);
+				if (i.hasAttributes()) for (let e of i.getAttributeNames()) if (e.endsWith(ie)) {
+					let t = u[o++], n = i.getAttribute(e).split(w), r = /([.?@])?(.*)/.exec(t);
 					c.push({
 						type: 1,
 						index: a,
 						name: r[2],
 						strings: n,
-						ctor: r[1] === "." ? Te : r[1] === "?" ? Ee : r[1] === "@" ? De : we
+						ctor: r[1] === "." ? De : r[1] === "?" ? Oe : r[1] === "@" ? ke : Ee
 					}), i.removeAttribute(e);
-				} else e.startsWith(T) && (c.push({
+				} else e.startsWith(w) && (c.push({
 					type: 6,
 					index: a
 				}), i.removeAttribute(e));
-				if (ge.test(i.tagName)) {
-					let e = i.textContent.split(T), t = e.length - 1;
+				if (_e.test(i.tagName)) {
+					let e = i.textContent.split(w), t = e.length - 1;
 					if (t > 0) {
-						i.textContent = te ? te.emptyScript : "";
-						for (let n = 0; n < t; n++) i.append(e[n], oe()), j.nextNode(), c.push({
+						i.textContent = ne ? ne.emptyScript : "";
+						for (let n = 0; n < t; n++) i.append(e[n], se()), ye.nextNode(), c.push({
 							type: 2,
 							index: ++a
 						});
-						i.append(e[t], oe());
+						i.append(e[t], se());
 					}
 				}
-			} else if (i.nodeType === 8) if (i.data === ie) c.push({
+			} else if (i.nodeType === 8) if (i.data === ae) c.push({
 				type: 2,
 				index: a
 			});
 			else {
 				let e = -1;
-				for (; (e = i.data.indexOf(T, e + 1)) !== -1;) c.push({
+				for (; (e = i.data.indexOf(w, e + 1)) !== -1;) c.push({
 					type: 7,
 					index: a
-				}), e += T.length - 1;
+				}), e += w.length - 1;
 			}
 			a++;
 		}
 	}
 	static createElement(e, t) {
-		let n = E.createElement("template");
+		let n = T.createElement("template");
 		return n.innerHTML = e, n;
 	}
 };
-function xe(e, t, n = e, r) {
-	if (t === k) return t;
-	let i = r === void 0 ? n._$Cl : n._$Co?.[r], a = se(t) ? void 0 : t._$litDirective$;
-	return i?.constructor !== a && (i?._$AO?.(!1), a === void 0 ? i = void 0 : (i = new a(e), i._$AT(e, n, r)), r === void 0 ? n._$Cl = i : (n._$Co ??= [])[r] = i), i !== void 0 && (t = xe(e, i._$AS(e, t.values), i, r)), t;
+function Ce(e, t, n = e, r) {
+	if (t === O) return t;
+	let i = r === void 0 ? n._$Cl : n._$Co?.[r], a = ce(t) ? void 0 : t._$litDirective$;
+	return i?.constructor !== a && (i?._$AO?.(!1), a === void 0 ? i = void 0 : (i = new a(e), i._$AT(e, n, r)), r === void 0 ? n._$Cl = i : (n._$Co ??= [])[r] = i), i !== void 0 && (t = Ce(e, i._$AS(e, t.values), i, r)), t;
 }
-var Se = class {
+var we = class {
 	constructor(e, t) {
 		this._$AV = [], this._$AN = void 0, this._$AD = e, this._$AM = t;
 	}
@@ -342,28 +342,28 @@ var Se = class {
 		return this._$AM._$AU;
 	}
 	u(e) {
-		let { el: { content: t }, parts: n } = this._$AD, r = (e?.creationScope ?? E).importNode(t, !0);
-		j.currentNode = r;
-		let i = j.nextNode(), a = 0, o = 0, s = n[0];
+		let { el: { content: t }, parts: n } = this._$AD, r = (e?.creationScope ?? T).importNode(t, !0);
+		ye.currentNode = r;
+		let i = ye.nextNode(), a = 0, o = 0, s = n[0];
 		for (; s !== void 0;) {
 			if (a === s.index) {
 				let t;
-				s.type === 2 ? t = new Ce(i, i.nextSibling, this, e) : s.type === 1 ? t = new s.ctor(i, s.name, s.strings, this, e) : s.type === 6 && (t = new Oe(i, this, e)), this._$AV.push(t), s = n[++o];
+				s.type === 2 ? t = new Te(i, i.nextSibling, this, e) : s.type === 1 ? t = new s.ctor(i, s.name, s.strings, this, e) : s.type === 6 && (t = new Ae(i, this, e)), this._$AV.push(t), s = n[++o];
 			}
-			a !== s?.index && (i = j.nextNode(), a++);
+			a !== s?.index && (i = ye.nextNode(), a++);
 		}
-		return j.currentNode = E, r;
+		return ye.currentNode = T, r;
 	}
 	p(e) {
 		let t = 0;
 		for (let n of this._$AV) n !== void 0 && (n.strings === void 0 ? n._$AI(e[t]) : (n._$AI(e, n, t), t += n.strings.length - 2)), t++;
 	}
-}, Ce = class e {
+}, Te = class e {
 	get _$AU() {
 		return this._$AM?._$AU ?? this._$Cv;
 	}
 	constructor(e, t, n, r) {
-		this.type = 2, this._$AH = A, this._$AN = void 0, this._$AA = e, this._$AB = t, this._$AM = n, this.options = r, this._$Cv = r?.isConnected ?? !0;
+		this.type = 2, this._$AH = k, this._$AN = void 0, this._$AA = e, this._$AB = t, this._$AM = n, this.options = r, this._$Cv = r?.isConnected ?? !0;
 	}
 	get parentNode() {
 		let e = this._$AA.parentNode, t = this._$AM;
@@ -376,7 +376,7 @@ var Se = class {
 		return this._$AB;
 	}
 	_$AI(e, t = this) {
-		e = xe(this, e, t), se(e) ? e === A || e == null || e === "" ? (this._$AH !== A && this._$AR(), this._$AH = A) : e !== this._$AH && e !== k && this._(e) : e._$litType$ === void 0 ? e.nodeType === void 0 ? le(e) ? this.k(e) : this._(e) : this.T(e) : this.$(e);
+		e = Ce(this, e, t), ce(e) ? e === k || e == null || e === "" ? (this._$AH !== k && this._$AR(), this._$AH = k) : e !== this._$AH && e !== O && this._(e) : e._$litType$ === void 0 ? e.nodeType === void 0 ? ue(e) ? this.k(e) : this._(e) : this.T(e) : this.$(e);
 	}
 	O(e) {
 		return this._$AA.parentNode.insertBefore(e, this._$AB);
@@ -385,36 +385,36 @@ var Se = class {
 		this._$AH !== e && (this._$AR(), this._$AH = this.O(e));
 	}
 	_(e) {
-		this._$AH !== A && se(this._$AH) ? this._$AA.nextSibling.data = e : this.T(E.createTextNode(e)), this._$AH = e;
+		this._$AH !== k && ce(this._$AH) ? this._$AA.nextSibling.data = e : this.T(T.createTextNode(e)), this._$AH = e;
 	}
 	$(e) {
-		let { values: t, _$litType$: n } = e, r = typeof n == "number" ? this._$AC(e) : (n.el === void 0 && (n.el = be.createElement(ve(n.h, n.h[0]), this.options)), n);
+		let { values: t, _$litType$: n } = e, r = typeof n == "number" ? this._$AC(e) : (n.el === void 0 && (n.el = Se.createElement(be(n.h, n.h[0]), this.options)), n);
 		if (this._$AH?._$AD === r) this._$AH.p(t);
 		else {
-			let e = new Se(r, this), n = e.u(this.options);
+			let e = new we(r, this), n = e.u(this.options);
 			e.p(t), this.T(n), this._$AH = e;
 		}
 	}
 	_$AC(e) {
-		let t = _e.get(e.strings);
-		return t === void 0 && _e.set(e.strings, t = new be(e)), t;
+		let t = ve.get(e.strings);
+		return t === void 0 && ve.set(e.strings, t = new Se(e)), t;
 	}
 	k(t) {
-		ce(this._$AH) || (this._$AH = [], this._$AR());
+		le(this._$AH) || (this._$AH = [], this._$AR());
 		let n = this._$AH, r, i = 0;
-		for (let a of t) i === n.length ? n.push(r = new e(this.O(oe()), this.O(oe()), this, this.options)) : r = n[i], r._$AI(a), i++;
+		for (let a of t) i === n.length ? n.push(r = new e(this.O(se()), this.O(se()), this, this.options)) : r = n[i], r._$AI(a), i++;
 		i < n.length && (this._$AR(r && r._$AB.nextSibling, i), n.length = i);
 	}
 	_$AR(e = this._$AA.nextSibling, t) {
 		for (this._$AP?.(!1, !0, t); e !== this._$AB;) {
-			let t = w(e).nextSibling;
-			w(e).remove(), e = t;
+			let t = C(e).nextSibling;
+			C(e).remove(), e = t;
 		}
 	}
 	setConnected(e) {
 		this._$AM === void 0 && (this._$Cv = e, this._$AP?.(e));
 	}
-}, we = class {
+}, Ee = class {
 	get tagName() {
 		return this.element.tagName;
 	}
@@ -422,47 +422,47 @@ var Se = class {
 		return this._$AM._$AU;
 	}
 	constructor(e, t, n, r, i) {
-		this.type = 1, this._$AH = A, this._$AN = void 0, this.element = e, this.name = t, this._$AM = r, this.options = i, n.length > 2 || n[0] !== "" || n[1] !== "" ? (this._$AH = Array(n.length - 1).fill(/* @__PURE__ */ new String()), this.strings = n) : this._$AH = A;
+		this.type = 1, this._$AH = k, this._$AN = void 0, this.element = e, this.name = t, this._$AM = r, this.options = i, n.length > 2 || n[0] !== "" || n[1] !== "" ? (this._$AH = Array(n.length - 1).fill(/* @__PURE__ */ new String()), this.strings = n) : this._$AH = k;
 	}
 	_$AI(e, t = this, n, r) {
 		let i = this.strings, a = !1;
-		if (i === void 0) e = xe(this, e, t, 0), a = !se(e) || e !== this._$AH && e !== k, a && (this._$AH = e);
+		if (i === void 0) e = Ce(this, e, t, 0), a = !ce(e) || e !== this._$AH && e !== O, a && (this._$AH = e);
 		else {
 			let r = e, o, s;
-			for (e = i[0], o = 0; o < i.length - 1; o++) s = xe(this, r[n + o], t, o), s === k && (s = this._$AH[o]), a ||= !se(s) || s !== this._$AH[o], s === A ? e = A : e !== A && (e += (s ?? "") + i[o + 1]), this._$AH[o] = s;
+			for (e = i[0], o = 0; o < i.length - 1; o++) s = Ce(this, r[n + o], t, o), s === O && (s = this._$AH[o]), a ||= !ce(s) || s !== this._$AH[o], s === k ? e = k : e !== k && (e += (s ?? "") + i[o + 1]), this._$AH[o] = s;
 		}
 		a && !r && this.j(e);
 	}
 	j(e) {
-		e === A ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, e ?? "");
+		e === k ? this.element.removeAttribute(this.name) : this.element.setAttribute(this.name, e ?? "");
 	}
-}, Te = class extends we {
+}, De = class extends Ee {
 	constructor() {
 		super(...arguments), this.type = 3;
 	}
 	j(e) {
-		this.element[this.name] = e === A ? void 0 : e;
+		this.element[this.name] = e === k ? void 0 : e;
 	}
-}, Ee = class extends we {
+}, Oe = class extends Ee {
 	constructor() {
 		super(...arguments), this.type = 4;
 	}
 	j(e) {
-		this.element.toggleAttribute(this.name, !!e && e !== A);
+		this.element.toggleAttribute(this.name, !!e && e !== k);
 	}
-}, De = class extends we {
+}, ke = class extends Ee {
 	constructor(e, t, n, r, i) {
 		super(e, t, n, r, i), this.type = 5;
 	}
 	_$AI(e, t = this) {
-		if ((e = xe(this, e, t, 0) ?? A) === k) return;
-		let n = this._$AH, r = e === A && n !== A || e.capture !== n.capture || e.once !== n.once || e.passive !== n.passive, i = e !== A && (n === A || r);
+		if ((e = Ce(this, e, t, 0) ?? k) === O) return;
+		let n = this._$AH, r = e === k && n !== k || e.capture !== n.capture || e.once !== n.once || e.passive !== n.passive, i = e !== k && (n === k || r);
 		r && this.element.removeEventListener(this.name, this, n), i && this.element.addEventListener(this.name, this, e), this._$AH = e;
 	}
 	handleEvent(e) {
 		typeof this._$AH == "function" ? this._$AH.call(this.options?.host ?? this.element, e) : this._$AH.handleEvent(e);
 	}
-}, Oe = class {
+}, Ae = class {
 	constructor(e, t, n) {
 		this.element = e, this.type = 6, this._$AN = void 0, this._$AM = t, this.options = n;
 	}
@@ -470,18 +470,18 @@ var Se = class {
 		return this._$AM._$AU;
 	}
 	_$AI(e) {
-		xe(this, e);
+		Ce(this, e);
 	}
-}, ke = C.litHtmlPolyfillSupport;
-ke?.(be, Ce), (C.litHtmlVersions ??= []).push("3.3.3");
-var Ae = (e, t, n) => {
+}, je = te.litHtmlPolyfillSupport;
+je?.(Se, Te), (te.litHtmlVersions ??= []).push("3.3.3");
+var Me = (e, t, n) => {
 	let r = n?.renderBefore ?? t, i = r._$litPart$;
 	if (i === void 0) {
 		let e = n?.renderBefore ?? null;
-		r._$litPart$ = i = new Ce(t.insertBefore(oe(), e), e, void 0, n ?? {});
+		r._$litPart$ = i = new Te(t.insertBefore(se(), e), e, void 0, n ?? {});
 	}
 	return i._$AI(e), i;
-}, je = globalThis, M = class extends S {
+}, Ne = globalThis, A = class extends S {
 	constructor() {
 		super(...arguments), this.renderOptions = { host: this }, this._$Do = void 0;
 	}
@@ -491,7 +491,7 @@ var Ae = (e, t, n) => {
 	}
 	update(e) {
 		let t = this.render();
-		this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(e), this._$Do = Ae(t, this.renderRoot, this.renderOptions);
+		this.hasUpdated || (this.renderOptions.isConnected = this.isConnected), super.update(e), this._$Do = Me(t, this.renderRoot, this.renderOptions);
 	}
 	connectedCallback() {
 		super.connectedCallback(), this._$Do?.setConnected(!0);
@@ -500,21 +500,21 @@ var Ae = (e, t, n) => {
 		super.disconnectedCallback(), this._$Do?.setConnected(!1);
 	}
 	render() {
-		return k;
+		return O;
 	}
 };
-M._$litElement$ = !0, M.finalized = !0, je.litElementHydrateSupport?.({ LitElement: M });
-var Me = je.litElementPolyfillSupport;
-Me?.({ LitElement: M }), (je.litElementVersions ??= []).push("4.2.2");
+A._$litElement$ = !0, A.finalized = !0, Ne.litElementHydrateSupport?.({ LitElement: A });
+var Pe = Ne.litElementPolyfillSupport;
+Pe?.({ LitElement: A }), (Ne.litElementVersions ??= []).push("4.2.2");
 //#endregion
 //#region node_modules/@lit/reactive-element/decorators/property.js
-var Ne = {
+var Fe = {
 	attribute: !0,
 	type: String,
 	converter: b,
 	reflect: !1,
 	hasChanged: x
-}, Pe = (e = Ne, t, n) => {
+}, Ie = (e = Fe, t, n) => {
 	let { kind: r, metadata: i } = n, a = globalThis.litPropertyMetadata.get(i);
 	if (a === void 0 && globalThis.litPropertyMetadata.set(i, a = /* @__PURE__ */ new Map()), r === "setter" && ((e = Object.create(e)).wrapped = !0), a.set(n.name, e), r === "accessor") {
 		let { name: r } = n;
@@ -537,16 +537,16 @@ var Ne = {
 	}
 	throw Error("Unsupported decorator location: " + r);
 };
-function N(e) {
-	return (t, n) => typeof n == "object" ? Pe(e, t, n) : ((e, t, n) => {
+function j(e) {
+	return (t, n) => typeof n == "object" ? Ie(e, t, n) : ((e, t, n) => {
 		let r = t.hasOwnProperty(n);
 		return t.constructor.createProperty(n, e), r ? Object.getOwnPropertyDescriptor(t, n) : void 0;
 	})(e, t, n);
 }
 //#endregion
 //#region node_modules/@lit/reactive-element/decorators/state.js
-function Fe(e) {
-	return N({
+function Le(e) {
+	return j({
 		...e,
 		state: !0,
 		attribute: !1
@@ -554,10 +554,10 @@ function Fe(e) {
 }
 //#endregion
 //#region node_modules/@lit/reactive-element/decorators/base.js
-var Ie = (e, t, n) => (n.configurable = !0, n.enumerable = !0, Reflect.decorate && typeof t != "object" && Object.defineProperty(e, t, n), n);
+var Re = (e, t, n) => (n.configurable = !0, n.enumerable = !0, Reflect.decorate && typeof t != "object" && Object.defineProperty(e, t, n), n);
 //#endregion
 //#region node_modules/@lit/reactive-element/decorators/query.js
-function Le(e, t) {
+function ze(e, t) {
 	return (n, r, i) => {
 		let a = (t) => t.renderRoot?.querySelector(e) ?? null;
 		if (t) {
@@ -572,29 +572,29 @@ function Le(e, t) {
 					}
 				};
 			})();
-			return Ie(n, r, { get() {
+			return Re(n, r, { get() {
 				let n = e.call(this);
 				return n === void 0 && (n = a(this), (n !== null || this.hasUpdated) && t.call(this, n)), n;
 			} });
 		}
-		return Ie(n, r, { get() {
+		return Re(n, r, { get() {
 			return a(this);
 		} });
 	};
 }
 //#endregion
 //#region node_modules/lit-html/directive.js
-var Re = {
+var Be = {
 	ATTRIBUTE: 1,
 	CHILD: 2,
 	PROPERTY: 3,
 	BOOLEAN_ATTRIBUTE: 4,
 	EVENT: 5,
 	ELEMENT: 6
-}, ze = (e) => (...t) => ({
+}, Ve = (e) => (...t) => ({
 	_$litDirective$: e,
 	values: t
-}), Be = class {
+}), He = class {
 	constructor(e) {}
 	get _$AU() {
 		return this._$AM._$AU;
@@ -608,13 +608,13 @@ var Re = {
 	update(e, t) {
 		return this.render(...t);
 	}
-}, Ve = class extends Be {
+}, Ue = class extends He {
 	constructor(e) {
-		if (super(e), this.it = A, e.type !== Re.CHILD) throw Error(this.constructor.directiveName + "() can only be used in child bindings");
+		if (super(e), this.it = k, e.type !== Be.CHILD) throw Error(this.constructor.directiveName + "() can only be used in child bindings");
 	}
 	render(e) {
-		if (e === A || e == null) return this._t = void 0, this.it = e;
-		if (e === k) return e;
+		if (e === k || e == null) return this._t = void 0, this.it = e;
+		if (e === O) return e;
 		if (typeof e != "string") throw Error(this.constructor.directiveName + "() called with a non-string value");
 		if (e === this.it) return this._t;
 		this.it = e;
@@ -626,26 +626,26 @@ var Re = {
 		};
 	}
 };
-Ve.directiveName = "unsafeHTML", Ve.resultType = 1;
-var He = ze(Ve), Ue = class extends Ve {};
-Ue.directiveName = "unsafeSVG", Ue.resultType = 2;
-var We = ze(Ue), Ge = "*,:before,:after{box-sizing:border-box}html,body,div,span,applet,object,iframe,h1,h2,h3,h4,h5,h6,p,blockquote,pre,a,abbr,acronym,address,big,cite,code,del,dfn,em,img,ins,kbd,q,s,samp,small,strike,strong,sub,sup,tt,var,b,u,i,center,dl,dt,dd,ol,ul,li,fieldset,form,label,legend,table,caption,tbody,tfoot,thead,tr,th,td,article,aside,canvas,details,embed,figure,figcaption,footer,header,hgroup,menu,nav,output,ruby,section,summary,time,mark,audio,video{font-size:100%;font:inherit;vertical-align:baseline;border:0;margin:0;padding:0}article,aside,details,figcaption,figure,footer,header,hgroup,menu,nav,section{display:block}[hidden]:not([hidden=until-found]){display:none!important}body,article,p,span,div,li,td,th,dt,dd,h1,h2,h3,h4,h5,h6{overflow-wrap:anywhere;line-break:strict}body{-webkit-text-size-adjust:100%;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;line-height:1}li{list-style:none}blockquote,q{quotes:none}blockquote:before,blockquote:after,q:before,q:after{content:\"\";content:none}table{border-collapse:collapse;border-spacing:0}a{color:inherit;text-decoration:none}button{all:unset;box-sizing:border-box}button,label,select,summary,[role=button],[role=option]{cursor:pointer}button,input,select,textarea{margin:0;font-family:inherit;font-size:100%}button,input{overflow:visible}button,select{text-transform:none}button,[type=button],[type=reset],[type=submit]{-webkit-appearance:button}button::-moz-focus-inner{border-style:none;padding:0}[type=button]::-moz-focus-inner{border-style:none;padding:0}[type=reset]::-moz-focus-inner{border-style:none;padding:0}[type=submit]::-moz-focus-inner{border-style:none;padding:0}@media (prefers-reduced-motion:reduce){*{scroll-behavior:auto!important;transition-duration:.01ms!important;animation-duration:.01ms!important;animation-iteration-count:1!important}}input[type=text],input[type=email],input[type=password],input[type=search],input[type=tel],input[type=url],input[type=number],textarea{-webkit-appearance:none}a,button,input,select,textarea{touch-action:manipulation}:focus{outline-offset:2px;outline:auto}:focus:not(:focus-visible){outline:0}:focus-visible{outline-offset:2px;outline:auto}img{max-width:100%;height:auto}", Ke = ":host{--font-weight-normal:400;--font-weight-bold:700}:host,:host *{font-family:Arial,YakuHanJPs,Hiragino Sans,Hiragino Kaku Gothic ProN,Meiryo,Noto Sans JP,sans-serif;font-weight:var(--font-weight-normal);overflow-wrap:anywhere;line-break:strict}:host :lang(ja),:host :lang(en){--font-weight-normal:300;--font-weight-bold:600}:host :lang(zh){font-family:Arial,YakuHanJPs,PingFang SC,Microsoft YaHei,PingFang TC,Microsoft JhengHei,sans-serif}:where(:focus-visible){outline:inherit}fieldset{border:none}button{box-sizing:border-box}";
+Ue.directiveName = "unsafeHTML", Ue.resultType = 1;
+var We = Ve(Ue), Ge = class extends Ue {};
+Ge.directiveName = "unsafeSVG", Ge.resultType = 2;
+var Ke = Ve(Ge), qe = "*,:before,:after{box-sizing:border-box}html,body,div,span,applet,object,iframe,h1,h2,h3,h4,h5,h6,p,blockquote,pre,a,abbr,acronym,address,big,cite,code,del,dfn,em,img,ins,kbd,q,s,samp,small,strike,strong,sub,sup,tt,var,b,u,i,center,dl,dt,dd,ol,ul,li,fieldset,form,label,legend,table,caption,tbody,tfoot,thead,tr,th,td,article,aside,canvas,details,embed,figure,figcaption,footer,header,hgroup,menu,nav,output,ruby,section,summary,time,mark,audio,video{font-size:100%;font:inherit;vertical-align:baseline;border:0;margin:0;padding:0}article,aside,details,figcaption,figure,footer,header,hgroup,menu,nav,section{display:block}[hidden]:not([hidden=until-found]){display:none!important}body,article,p,span,div,li,td,th,dt,dd,h1,h2,h3,h4,h5,h6{overflow-wrap:anywhere;line-break:strict}body{-webkit-text-size-adjust:100%;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;line-height:1}li{list-style:none}blockquote,q{quotes:none}blockquote:before,blockquote:after,q:before,q:after{content:\"\";content:none}table{border-collapse:collapse;border-spacing:0}a{color:inherit;text-decoration:none}button{all:unset;box-sizing:border-box}button,label,select,summary,[role=button],[role=option]{cursor:pointer}button,input,select,textarea{margin:0;font-family:inherit;font-size:100%}button,input{overflow:visible}button,select{text-transform:none}button,[type=button],[type=reset],[type=submit]{-webkit-appearance:button}button::-moz-focus-inner{border-style:none;padding:0}[type=button]::-moz-focus-inner{border-style:none;padding:0}[type=reset]::-moz-focus-inner{border-style:none;padding:0}[type=submit]::-moz-focus-inner{border-style:none;padding:0}@media (prefers-reduced-motion:reduce){*{scroll-behavior:auto!important;transition-duration:.01ms!important;animation-duration:.01ms!important;animation-iteration-count:1!important}}input[type=text],input[type=email],input[type=password],input[type=search],input[type=tel],input[type=url],input[type=number],textarea{-webkit-appearance:none}a,button,input,select,textarea{touch-action:manipulation}:focus{outline-offset:2px;outline:auto}:focus:not(:focus-visible){outline:0}:focus-visible{outline-offset:2px;outline:auto}img{max-width:100%;height:auto}", Je = ":host{--font-weight-normal:400;--font-weight-bold:700}:host,:host *{font-family:Arial,YakuHanJPs,Hiragino Sans,Hiragino Kaku Gothic ProN,Meiryo,Noto Sans JP,sans-serif;font-weight:var(--font-weight-normal);overflow-wrap:anywhere;line-break:strict}:host :lang(ja),:host :lang(en){--font-weight-normal:300;--font-weight-bold:600}:host :lang(zh){font-family:Arial,YakuHanJPs,PingFang SC,Microsoft YaHei,PingFang TC,Microsoft JhengHei,sans-serif}:where(:focus-visible){outline:inherit}fieldset{border:none}button{box-sizing:border-box}";
 //#endregion
 //#region src/components/styles.ts
-function P(...e) {
+function M(...e) {
 	return [
 		o`
-    ${a(Ge)}
+    ${a(qe)}
   `,
 		o`
-    ${a(Ke)}
+    ${a(Je)}
   `,
 		...e
 	];
 }
 //#endregion
 //#region src/components/icon/icon.css?inline
-var qe = ":host{pointer-events:none;width:1.28em;height:1.28em;display:inline-block}.icon{width:100%;height:100%}", Je = /* @__PURE__ */ "app.arrow-down.arrow-down-small.arrow-left.arrow-up.arrow-up-down.arrow-up-small.bell.bell-fill.book-ai.bookmark.bookmark-fill.building.building-add.building-cancel-fill.calendar.calendar-event.calendar-fill.chain.check.check-small.chevron-down.chevron-down-fill.chevron-down-small.chevron-left.chevron-left-small.chevron-right.chevron-right-fill.chevron-right-small.chevron-up.chevron-up-small.clock.copy.cross.cross-small.double-chevron-right.download.drag.error-fill.exit.eye.eye-slash.follow.follow-fill.follow-list.follow-list-fill.gear.headset.headset-face.history.home.home-fill.information.information-fill.kebab-menu.language.list-close.list-open.lock.lock-fill.magic.magic-fill.mail.mail-gear.maximize.menu.minimize.minus.minus-circle.minus-circle-fill.money.open-in-new.pencil-square.person.person-add.person-cancel-fill.person-fill.person-gear.plus.plus-circle.plus-circle-fill.plus-small.question-circle.refresh.report.route.search.search-fill.share.side-left.side-right.stop-fill.success.success-fill.unlock.unlock-fill.warning-fill".split("."), F = {
+var Ye = ":host{pointer-events:none;width:1.28em;height:1.28em;display:inline-block}.icon{width:100%;height:100%}", Xe = /* @__PURE__ */ "app.arrow-down.arrow-down-small.arrow-left.arrow-up.arrow-up-down.arrow-up-small.bell.bell-fill.book-ai.bookmark.bookmark-fill.building.building-add.building-cancel-fill.calendar.calendar-event.calendar-fill.chain.check.check-small.chevron-down.chevron-down-fill.chevron-down-small.chevron-left.chevron-left-small.chevron-right.chevron-right-fill.chevron-right-small.chevron-up.chevron-up-small.clock.copy.cross.cross-small.double-chevron-right.download.drag.error-fill.exit.eye.eye-slash.follow.follow-fill.follow-list.follow-list-fill.gear.headset.headset-face.history.home.home-fill.information.information-fill.kebab-menu.language.list-close.list-open.lock.lock-fill.magic.magic-fill.mail.mail-gear.maximize.menu.minimize.minus.minus-circle.minus-circle-fill.money.open-in-new.pencil-square.person.person-add.person-cancel-fill.person-fill.person-gear.plus.plus-circle.plus-circle-fill.plus-small.question-circle.refresh.report.route.search.search-fill.share.side-left.side-right.stop-fill.success.success-fill.unlock.unlock-fill.warning-fill".split("."), N = {
 	app: "<path d=\"M7.41 5.71C7.41 6.65 6.65 7.41 5.71 7.41C4.77 7.41 4.01 6.64 4.01 5.71C4.01 4.78 4.77 4.01 5.71 4.01C6.65 4.01 7.41 4.78 7.41 5.71ZM13.71 5.71C13.71 4.77 12.95 4.01 12.01 4.01C11.07 4.01 10.31 4.78 10.31 5.71C10.31 6.64 11.07 7.41 12.01 7.41C12.95 7.41 13.71 6.64 13.71 5.71ZM19.99 5.71C19.99 4.77 19.23 4.01 18.29 4.01C17.35 4.01 16.59 4.78 16.59 5.71C16.59 6.64 17.35 7.41 18.29 7.41C19.23 7.41 19.99 6.64 19.99 5.71ZM7.41 12C7.41 11.06 6.65 10.3 5.71 10.3C4.77 10.3 4.01 11.06 4.01 12C4.01 12.94 4.77 13.7 5.71 13.7C6.65 13.7 7.41 12.94 7.41 12ZM13.71 12C13.71 11.06 12.95 10.3 12.01 10.3C11.07 10.3 10.31 11.06 10.31 12C10.31 12.94 11.07 13.7 12.01 13.7C12.95 13.7 13.71 12.94 13.71 12ZM19.99 12.01C19.99 11.07 19.23 10.31 18.29 10.31C17.35 10.31 16.59 11.07 16.59 12.01C16.59 12.95 17.35 13.71 18.29 13.71C19.23 13.71 19.99 12.95 19.99 12.01ZM7.41 18.31C7.41 17.38 6.65 16.61 5.71 16.61C4.77 16.61 4.01 17.37 4.01 18.31C4.01 19.25 4.77 20.01 5.71 20.01C6.65 20.01 7.41 19.25 7.41 18.31ZM13.71 18.31C13.71 17.38 12.95 16.61 12.01 16.61C11.07 16.61 10.31 17.37 10.31 18.31C10.31 19.25 11.07 20.01 12.01 20.01C12.95 20.01 13.71 19.25 13.71 18.31ZM19.99 18.31C19.99 17.38 19.23 16.61 18.29 16.61C17.35 16.61 16.59 17.37 16.59 18.31C16.59 19.25 17.35 20.01 18.29 20.01C19.23 20.01 19.99 19.25 19.99 18.31Z\"/>",
 	"arrow-down": "<path d=\"M17.87 13.06L12.75 18.18V3.01001H11.25V18.18L6.13 13.06L5.07 14.12L12 21.05L18.93 14.12L17.87 13.06Z\"/>",
 	"arrow-down-small": "<path d=\"M15.58 12.37L12.76 15.19V6H11.26V15.19L8.43 12.36L7.37 13.42L12.01 18.06L16.64 13.43L15.58 12.37Z\"/>",
@@ -746,7 +746,7 @@ var qe = ":host{pointer-events:none;width:1.28em;height:1.28em;display:inline-bl
 };
 //#endregion
 //#region \0@oxc-project+runtime@0.132.0/helpers/decorate.js
-function I(e, t, n, r) {
+function P(e, t, n, r) {
 	var i = arguments.length, a = i < 3 ? t : r === null ? r = Object.getOwnPropertyDescriptor(t, n) : r, o;
 	if (typeof Reflect == "object" && typeof Reflect.decorate == "function") a = Reflect.decorate(e, t, n, r);
 	else for (var s = e.length - 1; s >= 0; s--) (o = e[s]) && (a = (i < 3 ? o(a) : i > 3 ? o(t, n, a) : o(t, n)) || a);
@@ -754,16 +754,16 @@ function I(e, t, n, r) {
 }
 //#endregion
 //#region src/components/icon/index.ts
-var Ye = {
-	...F,
-	"minus-cycle": F["minus-circle"],
-	"minus-cycle-fill": F["minus-circle-fill"],
-	"plus-cycle": F["plus-circle"],
-	"plus-cycle-fill": F["plus-circle-fill"],
-	question: F["question-circle"],
-	followlist: F["follow-list"],
-	"followlist-fill": F["follow-list-fill"]
-}, Xe = [
+var Ze = {
+	...N,
+	"minus-cycle": N["minus-circle"],
+	"minus-cycle-fill": N["minus-circle-fill"],
+	"plus-cycle": N["plus-circle"],
+	"plus-cycle-fill": N["plus-circle-fill"],
+	question: N["question-circle"],
+	followlist: N["follow-list"],
+	"followlist-fill": N["follow-list-fill"]
+}, Qe = [
 	"minus-cycle",
 	"minus-cycle-fill",
 	"plus-cycle",
@@ -771,37 +771,37 @@ var Ye = {
 	"question",
 	"followlist",
 	"followlist-fill"
-], Ze = [...Je, ...Xe];
-function Qe(e) {
-	return Ze.includes(e);
+], $e = [...Xe, ...Qe];
+function et(e) {
+	return $e.includes(e);
 }
-var $e = class extends M {
+var tt = class extends A {
 	constructor(...e) {
 		super(...e), this.type = "";
 	}
 	static {
-		this.styles = P(a(qe));
+		this.styles = M(a(Ye));
 	}
 	render() {
-		return Qe(this.type) ? O`<svg
+		return et(this.type) ? D`<svg
         class="icon"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
         aria-hidden="true"
       >
-        ${We(Ye[this.type])}
-      </svg>` : O``;
+        ${Ke(Ze[this.type])}
+      </svg>` : D``;
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0
-})], $e.prototype, "type", void 0);
-var et = class extends $e {};
-customElements.get("mi-icon") || customElements.define("mi-icon", $e), customElements.get("sp-icon") || customElements.define("sp-icon", et);
+})], tt.prototype, "type", void 0);
+var nt = class extends tt {};
+customElements.get("mi-icon") || customElements.define("mi-icon", tt), customElements.get("sp-icon") || customElements.define("sp-icon", nt);
 //#endregion
 //#region src/components/avatar/avatar.styles.ts
-var tt = o`
+var rt = o`
   :host {
     display: inline-block;
     --palette-plum: #910091;
@@ -972,13 +972,13 @@ var tt = o`
       color: rgb(0 0 0 / 35%);
     }
   }
-`, nt = [
+`, it = [
 	"small",
 	"medium",
 	"large",
 	"x-large",
 	"2x-large"
-], rt = [
+], at = [
 	"plum",
 	"violet",
 	"blue",
@@ -987,22 +987,22 @@ var tt = o`
 	"brown",
 	"red"
 ];
-function it(e) {
-	return nt.some((t) => t === e) ? e : (console.warn(`${e}は無効なsize属性です。`), "medium");
+function ot(e) {
+	return it.some((t) => t === e) ? e : (console.warn(`${e}は無効なsize属性です。`), "medium");
 }
-function at(e) {
-	return rt.some((t) => t === e);
+function st(e) {
+	return at.some((t) => t === e);
 }
-var L = class extends M {
+var F = class extends A {
 	constructor(...e) {
 		super(...e), this.src = "", this.alt = "", this.initials = "", this.size = "medium", this.color = "", this.inactive = !1;
 	}
 	static {
-		this.styles = P(tt);
+		this.styles = M(rt);
 	}
 	get #e() {
-		let e = ["base", `size-${it(this.size)}`];
-		return !this.src && this.#n && this.color && at(this.color) && e.push(`color-${this.color}`), this.inactive && e.push("inactive"), e.filter(Boolean).join(" ");
+		let e = ["base", `size-${ot(this.size)}`];
+		return !this.src && this.#n && this.color && st(this.color) && e.push(`color-${this.color}`), this.inactive && e.push("inactive"), e.filter(Boolean).join(" ");
 	}
 	#t() {
 		this.src = "";
@@ -1012,31 +1012,31 @@ var L = class extends M {
 	}
 	render() {
 		let e = this.#n;
-		return O`
+		return D`
       <div class="${this.#e}">
-        ${this.src ? O`
+        ${this.src ? D`
               <img
                 src="${this.src}"
                 alt="${this.alt}"
                 @error="${this.#t}"
                 class="image"
               />
-            ` : e ? O`<div class="initials">${e}</div>` : O`<div class="icon"><mi-icon type="person"></mi-icon></div>`}
+            ` : e ? D`<div class="initials">${e}</div>` : D`<div class="icon"><mi-icon type="person"></mi-icon></div>`}
       </div>
     `;
 	}
 };
-I([N({ type: String })], L.prototype, "src", void 0), I([N({ type: String })], L.prototype, "alt", void 0), I([N({ type: String })], L.prototype, "initials", void 0), I([N({ type: String })], L.prototype, "size", void 0), I([N({ type: String })], L.prototype, "color", void 0), I([N({ type: Boolean })], L.prototype, "inactive", void 0);
-var ot = class extends L {};
-customElements.get("mi-avatar") || customElements.define("mi-avatar", L), customElements.get("sp-avatar") || customElements.define("sp-avatar", ot);
+P([j({ type: String })], F.prototype, "src", void 0), P([j({ type: String })], F.prototype, "alt", void 0), P([j({ type: String })], F.prototype, "initials", void 0), P([j({ type: String })], F.prototype, "size", void 0), P([j({ type: String })], F.prototype, "color", void 0), P([j({ type: Boolean })], F.prototype, "inactive", void 0);
+var ct = class extends F {};
+customElements.get("mi-avatar") || customElements.define("mi-avatar", F), customElements.get("sp-avatar") || customElements.define("sp-avatar", ct);
 //#endregion
 //#region src/components/loading/loading.css?inline
-var st = ":host{--size-medium:12.5px;--size-large:15px;--size-x-large:17.5px;--size-2x-large:20px;--size-3x-large:26px;--size-4x-large:40px;--padding-medium:1.25px;--padding-large:1.5px;--padding-x-large:2px 2px 1.5px 1.5px;--padding-2x-large:2px;--padding-3x-large:3px;--padding-4x-large:4px;--border-size-ratio:1/10;--ui-semantic-object-regular-default:#000000d6;--neutral-neutral-20-alpha:#00000012;--background-normal:linear-gradient(white, white) padding-box padding-box,conic-gradient(var(--ui-semantic-object-regular-default) 0deg 270deg, var(--neutral-neutral-20-alpha) 270deg 360deg) border-box border-box;--background-ai:linear-gradient(white, white) padding-box padding-box,conic-gradient(#2a2af7 5%, #2a2af7 22%, #47d4ff 30%, #ff2ed5 73%, #f72a48 80%, #f72a48 84%, #2a2af7 100%) border-box border-box;flex-shrink:0;display:inline-flex}.base{display:flex}.base:has(.size-medium){padding:var(--padding-medium)}.base:has(.size-large){padding:var(--padding-large)}.base:has(.size-x-large){padding:var(--padding-x-large)}.base:has(.size-2x-large){padding:var(--padding-2x-large)}.base:has(.size-3x-large){padding:var(--padding-3x-large)}.base:has(.size-4x-large){padding:var(--padding-4x-large)}.size-medium{--size:var(--size-medium)}.size-large{--size:var(--size-large)}.size-x-large{--size:var(--size-x-large)}.size-2x-large{--size:var(--size-2x-large)}.size-3x-large{--size:var(--size-3x-large)}.size-4x-large{--size:var(--size-4x-large)}.loading{width:var(--size);height:var(--size);border:calc(var(--size) * var(--border-size-ratio)) solid transparent;border-radius:50%;animation:1s linear infinite spin;display:inline-block;-webkit-mask-image:radial-gradient(circle closest-side,#0000 80%,#000 80%);mask-image:radial-gradient(circle closest-side,#0000 80%,#000 80%)}.variant-ai{background:var(--background-ai)}.variant-normal{background:var(--background-normal)}@keyframes spin{0%{transform:rotate(0)}to{transform:rotate(360deg)}}", ct = class extends M {
+var lt = ":host{--size-medium:12.5px;--size-large:15px;--size-x-large:17.5px;--size-2x-large:20px;--size-3x-large:26px;--size-4x-large:40px;--padding-medium:1.25px;--padding-large:1.5px;--padding-x-large:2px 2px 1.5px 1.5px;--padding-2x-large:2px;--padding-3x-large:3px;--padding-4x-large:4px;--border-size-ratio:1/10;--ui-semantic-object-regular-default:#000000d6;--neutral-neutral-20-alpha:#00000012;--background-normal:linear-gradient(white, white) padding-box padding-box,conic-gradient(var(--ui-semantic-object-regular-default) 0deg 270deg, var(--neutral-neutral-20-alpha) 270deg 360deg) border-box border-box;--background-ai:linear-gradient(white, white) padding-box padding-box,conic-gradient(#2a2af7 5%, #2a2af7 22%, #47d4ff 30%, #ff2ed5 73%, #f72a48 80%, #f72a48 84%, #2a2af7 100%) border-box border-box;flex-shrink:0;display:inline-flex}.base{display:flex}.base:has(.size-medium){padding:var(--padding-medium)}.base:has(.size-large){padding:var(--padding-large)}.base:has(.size-x-large){padding:var(--padding-x-large)}.base:has(.size-2x-large){padding:var(--padding-2x-large)}.base:has(.size-3x-large){padding:var(--padding-3x-large)}.base:has(.size-4x-large){padding:var(--padding-4x-large)}.size-medium{--size:var(--size-medium)}.size-large{--size:var(--size-large)}.size-x-large{--size:var(--size-x-large)}.size-2x-large{--size:var(--size-2x-large)}.size-3x-large{--size:var(--size-3x-large)}.size-4x-large{--size:var(--size-4x-large)}.loading{width:var(--size);height:var(--size);border:calc(var(--size) * var(--border-size-ratio)) solid transparent;border-radius:50%;animation:1s linear infinite spin;display:inline-block;-webkit-mask-image:radial-gradient(circle closest-side,#0000 80%,#000 80%);mask-image:radial-gradient(circle closest-side,#0000 80%,#000 80%)}.variant-ai{background:var(--background-ai)}.variant-normal{background:var(--background-normal)}@keyframes spin{0%{transform:rotate(0)}to{transform:rotate(360deg)}}", ut = class extends A {
 	constructor(...e) {
 		super(...e), this.ai = !1, this.size = "medium";
 	}
 	static {
-		this.styles = P(a(st));
+		this.styles = M(a(lt));
 	}
 	get loadingClasses() {
 		return [
@@ -1053,19 +1053,19 @@ var st = ":host{--size-medium:12.5px;--size-large:15px;--size-x-large:17.5px;--s
 		].filter(Boolean).join(" ");
 	}
 	render() {
-		return O`
+		return D`
       <span class="base">
         <span class="${this.loadingClasses}" role="status"></span>
       </span>
     `;
 	}
 };
-I([N({ type: Boolean })], ct.prototype, "ai", void 0), I([N({ type: String })], ct.prototype, "size", void 0);
-var lt = class extends ct {};
-customElements.get("mi-loading") || customElements.define("mi-loading", ct), customElements.get("sp-loading") || customElements.define("sp-loading", lt);
+P([j({ type: Boolean })], ut.prototype, "ai", void 0), P([j({ type: String })], ut.prototype, "size", void 0);
+var dt = class extends ut {};
+customElements.get("mi-loading") || customElements.define("mi-loading", ut), customElements.get("sp-loading") || customElements.define("sp-loading", dt);
 //#endregion
 //#region src/components/button/button.styles.ts
-var ut = o`
+var ft = o`
   :host {
     display: inline-block;
   }
@@ -1378,29 +1378,29 @@ var ut = o`
       font-weight: var(--font-weight-bold);
     }
   }
-`, dt = [
+`, pt = [
 	"primary",
 	"secondary",
 	"tertiary",
 	"ghost",
 	"plane"
-], ft = [
+], mt = [
 	"medium",
 	"large",
 	"xLarge"
 ];
-function pt(e) {
-	return dt.some((t) => t === e);
-}
-function mt(e) {
-	return ft.some((t) => t === e);
-}
 function ht(e) {
-	return Qe(e) ? !0 : (console.warn(`${e}は無効なicon-type属性です。`), !1);
+	return pt.some((t) => t === e);
 }
-var R = class extends M {
+function gt(e) {
+	return mt.some((t) => t === e);
+}
+function _t(e) {
+	return et(e) ? !0 : (console.warn(`${e}は無効なicon-type属性です。`), !1);
+}
+var I = class extends A {
 	static {
-		this.styles = P(ut);
+		this.styles = M(ft);
 	}
 	static {
 		this.formAssociated = !0;
@@ -1413,17 +1413,17 @@ var R = class extends M {
 		super(), this.loading = !1, this.disabled = !1, this.selected = !1, this.toggle = !1, this.variant = "primary", this.size = "medium", this.name = "", this.value = "", this.type = "button", this.form = "", this.href = "", this.target = "", this.rel = "", this.iconType = "", this.#e = this.attachInternals();
 	}
 	getEffectiveVariant() {
-		let e = pt(this.variant);
-		return e || console.warn(`${this.variant}は無効なvariant属性です。`), e ? this.variant : dt[0];
+		let e = ht(this.variant);
+		return e || console.warn(`${this.variant}は無効なvariant属性です。`), e ? this.variant : pt[0];
 	}
 	get buttonClasses() {
 		let e = {
 			medium: "medium",
 			large: "large",
 			xLarge: "x-large"
-		}, t = mt(this.size);
+		}, t = gt(this.size);
 		t || console.warn(`${this.size}は無効なsize属性です。`);
-		let n = t ? this.size : ft[0];
+		let n = t ? this.size : mt[0];
 		return [
 			"base",
 			this.getTheme(),
@@ -1444,50 +1444,50 @@ var R = class extends M {
 			medium: "large",
 			large: "xLarge",
 			xLarge: "2xLarge"
-		}[mt(this.size) ? this.size : ft[0]];
+		}[gt(this.size) ? this.size : mt[0]];
 	}
 	renderLoading() {
-		return O`<mi-loading size="${this.loadingSize}"></mi-loading>`;
+		return D`<mi-loading size="${this.loadingSize}"></mi-loading>`;
 	}
 	get showIcon() {
-		return !this.loading && this.iconType && ht(this.iconType);
+		return !this.loading && this.iconType && _t(this.iconType);
 	}
 	renderIcon() {
-		return O`<mi-icon type="${this.iconType}" class="icon"></mi-icon>`;
+		return D`<mi-icon type="${this.iconType}" class="icon"></mi-icon>`;
 	}
 	renderSlot() {
-		return O`<slot class="text"></slot>`;
+		return D`<slot class="text"></slot>`;
 	}
 	get effectiveRel() {
 		return this.rel ? this.rel : this.target === "_blank" ? "noopener noreferrer" : "";
 	}
 	renderContent() {
-		return O`${this.loading ? this.renderLoading() : A}${this.showIcon ? this.renderIcon() : A}
+		return D`${this.loading ? this.renderLoading() : k}${this.showIcon ? this.renderIcon() : k}
     ${this.renderSlot()}`;
 	}
 	render() {
-		return this.isLink ? O`
+		return this.isLink ? D`
         <a
           class="${this.buttonClasses}"
-          href="${this.isDisabled ? A : this.href}"
-          target="${this.target || A}"
-          rel="${this.effectiveRel || A}"
-          aria-disabled="${this.isDisabled ? "true" : A}"
-          aria-busy="${this.loading ? "true" : A}"
+          href="${this.isDisabled ? k : this.href}"
+          target="${this.target || k}"
+          rel="${this.effectiveRel || k}"
+          aria-disabled="${this.isDisabled ? "true" : k}"
+          aria-busy="${this.loading ? "true" : k}"
           @click="${this.handleLinkClick}"
         >
           ${this.renderContent()}
         </a>
-      ` : O`
+      ` : D`
       <button
         class="${this.buttonClasses}"
         ?disabled="${this.isDisabled}"
-        name="${this.name || A}"
-        value="${this.value || A}"
+        name="${this.name || k}"
+        value="${this.value || k}"
         type="${this.type}"
-        form="${this.form || A}"
-        aria-pressed="${this.toggle ? this.selected ? "true" : "false" : A}"
-        aria-busy="${this.loading ? "true" : A}"
+        form="${this.form || k}"
+        aria-pressed="${this.toggle ? this.selected ? "true" : "false" : k}"
+        aria-busy="${this.loading ? "true" : k}"
         @click="${this.handleClick}"
       >
         ${this.renderContent()}
@@ -1509,28 +1509,28 @@ var R = class extends M {
 		this.dispatchEvent(new MouseEvent("click", e)) || e.preventDefault();
 	}
 };
-I([N({
+P([j({
 	type: Boolean,
 	reflect: !0
-})], R.prototype, "loading", void 0), I([N({
+})], I.prototype, "loading", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], R.prototype, "disabled", void 0), I([N({
+})], I.prototype, "disabled", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], R.prototype, "selected", void 0), I([N({
+})], I.prototype, "selected", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], R.prototype, "toggle", void 0), I([N({
+})], I.prototype, "toggle", void 0), P([j({
 	type: String,
 	reflect: !0
-})], R.prototype, "variant", void 0), I([N({
+})], I.prototype, "variant", void 0), P([j({
 	type: String,
 	reflect: !0
-})], R.prototype, "size", void 0), I([N({ type: String })], R.prototype, "name", void 0), I([N({ type: String })], R.prototype, "value", void 0), I([N({ type: String })], R.prototype, "type", void 0), I([N({ type: String })], R.prototype, "form", void 0), I([N({ type: String })], R.prototype, "href", void 0), I([N({ type: String })], R.prototype, "target", void 0), I([N({ type: String })], R.prototype, "rel", void 0), I([N({
+})], I.prototype, "size", void 0), P([j({ type: String })], I.prototype, "name", void 0), P([j({ type: String })], I.prototype, "value", void 0), P([j({ type: String })], I.prototype, "type", void 0), P([j({ type: String })], I.prototype, "form", void 0), P([j({ type: String })], I.prototype, "href", void 0), P([j({ type: String })], I.prototype, "target", void 0), P([j({ type: String })], I.prototype, "rel", void 0), P([j({
 	type: String,
 	attribute: "icon-type"
-})], R.prototype, "iconType", void 0);
+})], I.prototype, "iconType", void 0);
 //#endregion
 //#region src/components/button/mi-ai-button.ts
 try {
@@ -1541,7 +1541,7 @@ try {
 		inherits: !1
 	});
 } catch {}
-var gt = class extends R {
+var vt = class extends I {
 	constructor(...e) {
 		super(...e), this.variant = "primary", this.iconType = "";
 	}
@@ -1552,19 +1552,19 @@ var gt = class extends R {
 		return !this.loading;
 	}
 	renderIcon() {
-		return O`<mi-icon type="magic-fill" class="icon"></mi-icon>`;
+		return D`<mi-icon type="magic-fill" class="icon"></mi-icon>`;
 	}
 	renderLoading() {
-		return O`<mi-loading
+		return D`<mi-loading
       size="${this.loadingSize}"
       ?ai="${this.variant === "primary"}"
     ></mi-loading>`;
 	}
 };
-I([N({ type: String })], gt.prototype, "variant", void 0), I([N({ attribute: !1 })], gt.prototype, "iconType", void 0), customElements.get("mi-ai-button") || customElements.define("mi-ai-button", gt);
+P([j({ type: String })], vt.prototype, "variant", void 0), P([j({ attribute: !1 })], vt.prototype, "iconType", void 0), customElements.get("mi-ai-button") || customElements.define("mi-ai-button", vt);
 //#endregion
 //#region src/components/button/mi-danger-button.ts
-var _t = class extends R {
+var yt = class extends I {
 	constructor(...e) {
 		super(...e), this.variant = "primary";
 	}
@@ -1572,78 +1572,78 @@ var _t = class extends R {
 		return "danger";
 	}
 };
-I([N({ type: String })], _t.prototype, "variant", void 0), customElements.get("mi-danger-button") || customElements.define("mi-danger-button", _t);
+P([j({ type: String })], yt.prototype, "variant", void 0), customElements.get("mi-danger-button") || customElements.define("mi-danger-button", yt);
 //#endregion
 //#region node_modules/@floating-ui/utils/dist/floating-ui.utils.mjs
-var vt = Math.min, z = Math.max, yt = Math.round, bt = Math.floor, B = (e) => ({
+var bt = Math.min, xt = Math.max, St = Math.round, Ct = Math.floor, L = (e) => ({
 	x: e,
 	y: e
-}), xt = {
+}), wt = {
 	left: "right",
 	right: "left",
 	bottom: "top",
 	top: "bottom"
 };
-function St(e, t, n) {
-	return z(e, vt(t, n));
+function Tt(e, t, n) {
+	return xt(e, bt(t, n));
 }
-function Ct(e, t) {
+function Et(e, t) {
 	return typeof e == "function" ? e(t) : e;
 }
-function wt(e) {
+function R(e) {
 	return e.split("-")[0];
 }
-function Tt(e) {
+function Dt(e) {
 	return e.split("-")[1];
 }
-function Et(e) {
+function Ot(e) {
 	return e === "x" ? "y" : "x";
 }
-function Dt(e) {
+function kt(e) {
 	return e === "y" ? "height" : "width";
 }
-function V(e) {
+function z(e) {
 	let t = e[0];
 	return t === "t" || t === "b" ? "y" : "x";
 }
-function Ot(e) {
-	return Et(V(e));
-}
-function kt(e, t, n) {
-	n === void 0 && (n = !1);
-	let r = Tt(e), i = Ot(e), a = Dt(i), o = i === "x" ? r === (n ? "end" : "start") ? "right" : "left" : r === "start" ? "bottom" : "top";
-	return t.reference[a] > t.floating[a] && (o = Rt(o)), [o, Rt(o)];
-}
 function At(e) {
-	let t = Rt(e);
+	return Ot(z(e));
+}
+function jt(e, t, n) {
+	n === void 0 && (n = !1);
+	let r = Dt(e), i = At(e), a = kt(i), o = i === "x" ? r === (n ? "end" : "start") ? "right" : "left" : r === "start" ? "bottom" : "top";
+	return t.reference[a] > t.floating[a] && (o = Bt(o)), [o, Bt(o)];
+}
+function Mt(e) {
+	let t = Bt(e);
 	return [
-		jt(e),
+		Nt(e),
 		t,
-		jt(t)
+		Nt(t)
 	];
 }
-function jt(e) {
+function Nt(e) {
 	return e.includes("start") ? e.replace("start", "end") : e.replace("end", "start");
 }
-var Mt = ["left", "right"], Nt = ["right", "left"], Pt = ["top", "bottom"], Ft = ["bottom", "top"];
-function It(e, t, n) {
+var Pt = ["left", "right"], Ft = ["right", "left"], It = ["top", "bottom"], Lt = ["bottom", "top"];
+function Rt(e, t, n) {
 	switch (e) {
 		case "top":
-		case "bottom": return n ? t ? Nt : Mt : t ? Mt : Nt;
+		case "bottom": return n ? t ? Ft : Pt : t ? Pt : Ft;
 		case "left":
-		case "right": return t ? Pt : Ft;
+		case "right": return t ? It : Lt;
 		default: return [];
 	}
 }
-function Lt(e, t, n, r) {
-	let i = Tt(e), a = It(wt(e), n === "start", r);
-	return i && (a = a.map((e) => e + "-" + i), t && (a = a.concat(a.map(jt)))), a;
+function zt(e, t, n, r) {
+	let i = Dt(e), a = Rt(R(e), n === "start", r);
+	return i && (a = a.map((e) => e + "-" + i), t && (a = a.concat(a.map(Nt)))), a;
 }
-function Rt(e) {
-	let t = wt(e);
-	return xt[t] + e.slice(t.length);
+function Bt(e) {
+	let t = R(e);
+	return wt[t] + e.slice(t.length);
 }
-function zt(e) {
+function Vt(e) {
 	return {
 		top: 0,
 		right: 0,
@@ -1652,15 +1652,15 @@ function zt(e) {
 		...e
 	};
 }
-function Bt(e) {
+function Ht(e) {
 	return typeof e == "number" ? {
 		top: e,
 		right: e,
 		bottom: e,
 		left: e
-	} : zt(e);
+	} : Vt(e);
 }
-function Vt(e) {
+function Ut(e) {
 	let { x: t, y: n, width: r, height: i } = e;
 	return {
 		width: r,
@@ -1675,8 +1675,8 @@ function Vt(e) {
 }
 //#endregion
 //#region node_modules/@floating-ui/core/dist/floating-ui.core.mjs
-function Ht(e, t, n) {
-	let { reference: r, floating: i } = e, a = V(t), o = Ot(t), s = Dt(o), c = wt(t), l = a === "y", u = r.x + r.width / 2 - i.width / 2, d = r.y + r.height / 2 - i.height / 2, f = r[s] / 2 - i[s] / 2, p;
+function Wt(e, t, n) {
+	let { reference: r, floating: i } = e, a = z(t), o = At(t), s = kt(o), c = R(t), l = a === "y", u = r.x + r.width / 2 - i.width / 2, d = r.y + r.height / 2 - i.height / 2, f = r[s] / 2 - i[s] / 2, p;
 	switch (c) {
 		case "top":
 			p = {
@@ -1707,7 +1707,7 @@ function Ht(e, t, n) {
 			y: r.y
 		};
 	}
-	switch (Tt(t)) {
+	switch (Dt(t)) {
 		case "start":
 			p[o] -= f * (n && l ? -1 : 1);
 			break;
@@ -1717,9 +1717,9 @@ function Ht(e, t, n) {
 	}
 	return p;
 }
-async function Ut(e, t) {
+async function Gt(e, t) {
 	t === void 0 && (t = {});
-	let { x: n, y: r, platform: i, rects: a, elements: o, strategy: s } = e, { boundary: c = "clippingAncestors", rootBoundary: l = "viewport", elementContext: u = "floating", altBoundary: d = !1, padding: f = 0 } = Ct(t, e), p = Bt(f), m = o[d ? u === "floating" ? "reference" : "floating" : u], h = Vt(await i.getClippingRect({
+	let { x: n, y: r, platform: i, rects: a, elements: o, strategy: s } = e, { boundary: c = "clippingAncestors", rootBoundary: l = "viewport", elementContext: u = "floating", altBoundary: d = !1, padding: f = 0 } = Et(t, e), p = Ht(f), m = o[d ? u === "floating" ? "reference" : "floating" : u], h = Ut(await i.getClippingRect({
 		element: await (i.isElement == null ? void 0 : i.isElement(m)) ?? !0 ? m : m.contextElement || await (i.getDocumentElement == null ? void 0 : i.getDocumentElement(o.floating)),
 		boundary: c,
 		rootBoundary: l,
@@ -1732,7 +1732,7 @@ async function Ut(e, t) {
 	} : a.reference, _ = await (i.getOffsetParent == null ? void 0 : i.getOffsetParent(o.floating)), v = await (i.isElement == null ? void 0 : i.isElement(_)) && await (i.getScale == null ? void 0 : i.getScale(_)) || {
 		x: 1,
 		y: 1
-	}, y = Vt(i.convertOffsetParentRelativeRectToViewportRelativeRect ? await i.convertOffsetParentRelativeRectToViewportRelativeRect({
+	}, y = Ut(i.convertOffsetParentRelativeRectToViewportRelativeRect ? await i.convertOffsetParentRelativeRectToViewportRelativeRect({
 		elements: o,
 		rect: g,
 		offsetParent: _,
@@ -1745,15 +1745,15 @@ async function Ut(e, t) {
 		right: (y.right - h.right + p.right) / v.x
 	};
 }
-var Wt = 50, Gt = async (e, t, n) => {
+var Kt = 50, qt = async (e, t, n) => {
 	let { placement: r = "bottom", strategy: i = "absolute", middleware: a = [], platform: o } = n, s = o.detectOverflow ? o : {
 		...o,
-		detectOverflow: Ut
+		detectOverflow: Gt
 	}, c = await (o.isRTL == null ? void 0 : o.isRTL(t)), l = await o.getElementRects({
 		reference: e,
 		floating: t,
 		strategy: i
-	}), { x: u, y: d } = Ht(l, r, c), f = r, p = 0, m = {};
+	}), { x: u, y: d } = Wt(l, r, c), f = r, p = 0, m = {};
 	for (let n = 0; n < a.length; n++) {
 		let h = a[n];
 		if (!h) continue;
@@ -1774,11 +1774,11 @@ var Wt = 50, Gt = async (e, t, n) => {
 		u = v ?? u, d = y ?? d, m[g] = {
 			...m[g],
 			...b
-		}, x && p < Wt && (p++, typeof x == "object" && (x.placement && (f = x.placement), x.rects && (l = x.rects === !0 ? await o.getElementRects({
+		}, x && p < Kt && (p++, typeof x == "object" && (x.placement && (f = x.placement), x.rects && (l = x.rects === !0 ? await o.getElementRects({
 			reference: e,
 			floating: t,
 			strategy: i
-		}) : x.rects), {x: u, y: d} = Ht(l, f, c)), n = -1);
+		}) : x.rects), {x: u, y: d} = Wt(l, f, c)), n = -1);
 	}
 	return {
 		x: u,
@@ -1787,39 +1787,39 @@ var Wt = 50, Gt = async (e, t, n) => {
 		strategy: i,
 		middlewareData: m
 	};
-}, Kt = function(e) {
+}, Jt = function(e) {
 	return e === void 0 && (e = {}), {
 		name: "flip",
 		options: e,
 		async fn(t) {
 			var n;
-			let { placement: r, middlewareData: i, rects: a, initialPlacement: o, platform: s, elements: c } = t, { mainAxis: l = !0, crossAxis: u = !0, fallbackPlacements: d, fallbackStrategy: f = "bestFit", fallbackAxisSideDirection: p = "none", flipAlignment: m = !0, ...h } = Ct(e, t);
+			let { placement: r, middlewareData: i, rects: a, initialPlacement: o, platform: s, elements: c } = t, { mainAxis: l = !0, crossAxis: u = !0, fallbackPlacements: d, fallbackStrategy: f = "bestFit", fallbackAxisSideDirection: p = "none", flipAlignment: m = !0, ...h } = Et(e, t);
 			if ((n = i.arrow) != null && n.alignmentOffset) return {};
-			let g = wt(r), _ = V(o), v = wt(o) === o, y = await (s.isRTL == null ? void 0 : s.isRTL(c.floating)), b = d || (v || !m ? [Rt(o)] : At(o)), x = p !== "none";
-			!d && x && b.push(...Lt(o, m, p, y));
-			let ee = [o, ...b], S = await s.detectOverflow(t, h), C = [], w = i.flip?.overflows || [];
-			if (l && C.push(S[g]), u) {
-				let e = kt(r, a, y);
-				C.push(S[e[0]], S[e[1]]);
+			let g = R(r), _ = z(o), v = R(o) === o, y = await (s.isRTL == null ? void 0 : s.isRTL(c.floating)), b = d || (v || !m ? [Bt(o)] : Mt(o)), x = p !== "none";
+			!d && x && b.push(...zt(o, m, p, y));
+			let ee = [o, ...b], S = await s.detectOverflow(t, h), te = [], C = i.flip?.overflows || [];
+			if (l && te.push(S[g]), u) {
+				let e = jt(r, a, y);
+				te.push(S[e[0]], S[e[1]]);
 			}
-			if (w = [...w, {
+			if (C = [...C, {
 				placement: r,
-				overflows: C
-			}], !C.every((e) => e <= 0)) {
+				overflows: te
+			}], !te.every((e) => e <= 0)) {
 				let e = (i.flip?.index || 0) + 1, t = ee[e];
-				if (t && (!(u === "alignment" && _ !== V(t)) || w.every((e) => V(e.placement) === _ ? e.overflows[0] > 0 : !0))) return {
+				if (t && (!(u === "alignment" && _ !== z(t)) || C.every((e) => z(e.placement) === _ ? e.overflows[0] > 0 : !0))) return {
 					data: {
 						index: e,
-						overflows: w
+						overflows: C
 					},
 					reset: { placement: t }
 				};
-				let n = w.filter((e) => e.overflows[0] <= 0).sort((e, t) => e.overflows[1] - t.overflows[1])[0]?.placement;
+				let n = C.filter((e) => e.overflows[0] <= 0).sort((e, t) => e.overflows[1] - t.overflows[1])[0]?.placement;
 				if (!n) switch (f) {
 					case "bestFit": {
-						let e = w.filter((e) => {
+						let e = C.filter((e) => {
 							if (x) {
-								let t = V(e.placement);
+								let t = z(e.placement);
 								return t === _ || t === "y";
 							}
 							return !0;
@@ -1836,9 +1836,9 @@ var Wt = 50, Gt = async (e, t, n) => {
 			return {};
 		}
 	};
-}, qt = /* @__PURE__ */ new Set(["left", "top"]);
-async function Jt(e, t) {
-	let { placement: n, platform: r, elements: i } = e, a = await (r.isRTL == null ? void 0 : r.isRTL(i.floating)), o = wt(n), s = Tt(n), c = V(n) === "y", l = qt.has(o) ? -1 : 1, u = a && c ? -1 : 1, d = Ct(t, e), { mainAxis: f, crossAxis: p, alignmentAxis: m } = typeof d == "number" ? {
+}, Yt = /* @__PURE__ */ new Set(["left", "top"]);
+async function Xt(e, t) {
+	let { placement: n, platform: r, elements: i } = e, a = await (r.isRTL == null ? void 0 : r.isRTL(i.floating)), o = R(n), s = Dt(n), c = z(n) === "y", l = Yt.has(o) ? -1 : 1, u = a && c ? -1 : 1, d = Et(t, e), { mainAxis: f, crossAxis: p, alignmentAxis: m } = typeof d == "number" ? {
 		mainAxis: d,
 		crossAxis: 0,
 		alignmentAxis: null
@@ -1855,13 +1855,13 @@ async function Jt(e, t) {
 		y: p * u
 	};
 }
-var Yt = function(e) {
+var Zt = function(e) {
 	return e === void 0 && (e = 0), {
 		name: "offset",
 		options: e,
 		async fn(t) {
 			var n;
-			let { x: r, y: i, placement: a, middlewareData: o } = t, s = await Jt(t, e);
+			let { x: r, y: i, placement: a, middlewareData: o } = t, s = await Xt(t, e);
 			return a === o.offset?.placement && (n = o.arrow) != null && n.alignmentOffset ? {} : {
 				x: r + s.x,
 				y: i + s.y,
@@ -1872,7 +1872,7 @@ var Yt = function(e) {
 			};
 		}
 	};
-}, Xt = function(e) {
+}, Qt = function(e) {
 	return e === void 0 && (e = {}), {
 		name: "shift",
 		options: e,
@@ -1883,17 +1883,17 @@ var Yt = function(e) {
 					x: t,
 					y: n
 				};
-			} }, ...l } = Ct(e, t), u = {
+			} }, ...l } = Et(e, t), u = {
 				x: n,
 				y: r
-			}, d = await a.detectOverflow(t, l), f = V(wt(i)), p = Et(f), m = u[p], h = u[f];
+			}, d = await a.detectOverflow(t, l), f = z(R(i)), p = Ot(f), m = u[p], h = u[f];
 			if (o) {
 				let e = p === "y" ? "top" : "left", t = p === "y" ? "bottom" : "right", n = m + d[e], r = m - d[t];
-				m = St(n, m, r);
+				m = Tt(n, m, r);
 			}
 			if (s) {
 				let e = f === "y" ? "top" : "left", t = f === "y" ? "bottom" : "right", n = h + d[e], r = h - d[t];
-				h = St(n, h, r);
+				h = Tt(n, h, r);
 			}
 			let g = c.fn({
 				...t,
@@ -1916,39 +1916,39 @@ var Yt = function(e) {
 };
 //#endregion
 //#region node_modules/@floating-ui/utils/dist/floating-ui.utils.dom.mjs
-function Zt() {
+function $t() {
 	return typeof window < "u";
 }
-function Qt(e) {
-	return $t(e) ? (e.nodeName || "").toLowerCase() : "#document";
+function en(e) {
+	return tn(e) ? (e.nodeName || "").toLowerCase() : "#document";
 }
-function H(e) {
+function B(e) {
 	var t;
 	return (e == null || (t = e.ownerDocument) == null ? void 0 : t.defaultView) || window;
 }
-function U(e) {
-	return (($t(e) ? e.ownerDocument : e.document) || window.document)?.documentElement;
-}
-function $t(e) {
-	return Zt() ? e instanceof Node || e instanceof H(e).Node : !1;
-}
-function W(e) {
-	return Zt() ? e instanceof Element || e instanceof H(e).Element : !1;
-}
-function G(e) {
-	return Zt() ? e instanceof HTMLElement || e instanceof H(e).HTMLElement : !1;
-}
-function en(e) {
-	return !Zt() || typeof ShadowRoot > "u" ? !1 : e instanceof ShadowRoot || e instanceof H(e).ShadowRoot;
+function V(e) {
+	return ((tn(e) ? e.ownerDocument : e.document) || window.document)?.documentElement;
 }
 function tn(e) {
-	let { overflow: t, overflowX: n, overflowY: r, display: i } = q(e);
-	return /auto|scroll|overlay|hidden|clip/.test(t + r + n) && i !== "inline" && i !== "contents";
+	return $t() ? e instanceof Node || e instanceof B(e).Node : !1;
+}
+function H(e) {
+	return $t() ? e instanceof Element || e instanceof B(e).Element : !1;
+}
+function U(e) {
+	return $t() ? e instanceof HTMLElement || e instanceof B(e).HTMLElement : !1;
 }
 function nn(e) {
-	return /^(table|td|th)$/.test(Qt(e));
+	return !$t() || typeof ShadowRoot > "u" ? !1 : e instanceof ShadowRoot || e instanceof B(e).ShadowRoot;
 }
 function rn(e) {
+	let { overflow: t, overflowX: n, overflowY: r, display: i } = W(e);
+	return /auto|scroll|overlay|hidden|clip/.test(t + r + n) && i !== "inline" && i !== "contents";
+}
+function an(e) {
+	return /^(table|td|th)$/.test(en(e));
+}
+function on(e) {
 	try {
 		if (e.matches(":popover-open")) return !0;
 	} catch {}
@@ -1958,31 +1958,31 @@ function rn(e) {
 		return !1;
 	}
 }
-var an = /transform|translate|scale|rotate|perspective|filter/, on = /paint|layout|strict|content/, K = (e) => !!e && e !== "none", sn;
-function cn(e) {
-	let t = W(e) ? q(e) : e;
-	return K(t.transform) || K(t.translate) || K(t.scale) || K(t.rotate) || K(t.perspective) || !un() && (K(t.backdropFilter) || K(t.filter)) || an.test(t.willChange || "") || on.test(t.contain || "");
+var sn = /transform|translate|scale|rotate|perspective|filter/, cn = /paint|layout|strict|content/, ln = (e) => !!e && e !== "none", un;
+function dn(e) {
+	let t = H(e) ? W(e) : e;
+	return ln(t.transform) || ln(t.translate) || ln(t.scale) || ln(t.rotate) || ln(t.perspective) || !pn() && (ln(t.backdropFilter) || ln(t.filter)) || sn.test(t.willChange || "") || cn.test(t.contain || "");
 }
-function ln(e) {
-	let t = J(e);
-	for (; G(t) && !dn(t);) {
-		if (cn(t)) return t;
-		if (rn(t)) return null;
-		t = J(t);
+function fn(e) {
+	let t = G(e);
+	for (; U(t) && !mn(t);) {
+		if (dn(t)) return t;
+		if (on(t)) return null;
+		t = G(t);
 	}
 	return null;
 }
-function un() {
-	return sn ??= typeof CSS < "u" && CSS.supports && CSS.supports("-webkit-backdrop-filter", "none"), sn;
+function pn() {
+	return un ??= typeof CSS < "u" && CSS.supports && CSS.supports("-webkit-backdrop-filter", "none"), un;
 }
-function dn(e) {
-	return /^(html|body|#document)$/.test(Qt(e));
+function mn(e) {
+	return /^(html|body|#document)$/.test(en(e));
 }
-function q(e) {
-	return H(e).getComputedStyle(e);
+function W(e) {
+	return B(e).getComputedStyle(e);
 }
-function fn(e) {
-	return W(e) ? {
+function hn(e) {
+	return H(e) ? {
 		scrollLeft: e.scrollLeft,
 		scrollTop: e.scrollTop
 	} : {
@@ -1990,101 +1990,101 @@ function fn(e) {
 		scrollTop: e.scrollY
 	};
 }
-function J(e) {
-	if (Qt(e) === "html") return e;
-	let t = e.assignedSlot || e.parentNode || en(e) && e.host || U(e);
-	return en(t) ? t.host : t;
+function G(e) {
+	if (en(e) === "html") return e;
+	let t = e.assignedSlot || e.parentNode || nn(e) && e.host || V(e);
+	return nn(t) ? t.host : t;
 }
-function pn(e) {
-	let t = J(e);
-	return dn(t) ? e.ownerDocument ? e.ownerDocument.body : e.body : G(t) && tn(t) ? t : pn(t);
+function gn(e) {
+	let t = G(e);
+	return mn(t) ? e.ownerDocument ? e.ownerDocument.body : e.body : U(t) && rn(t) ? t : gn(t);
 }
-function mn(e, t, n) {
+function _n(e, t, n) {
 	t === void 0 && (t = []), n === void 0 && (n = !0);
-	let r = pn(e), i = r === e.ownerDocument?.body, a = H(r);
+	let r = gn(e), i = r === e.ownerDocument?.body, a = B(r);
 	if (i) {
-		let e = hn(a);
-		return t.concat(a, a.visualViewport || [], tn(r) ? r : [], e && n ? mn(e) : []);
-	} else return t.concat(r, mn(r, [], n));
+		let e = vn(a);
+		return t.concat(a, a.visualViewport || [], rn(r) ? r : [], e && n ? _n(e) : []);
+	} else return t.concat(r, _n(r, [], n));
 }
-function hn(e) {
+function vn(e) {
 	return e.parent && Object.getPrototypeOf(e.parent) ? e.frameElement : null;
 }
 //#endregion
 //#region node_modules/@floating-ui/dom/dist/floating-ui.dom.mjs
-function gn(e) {
-	let t = q(e), n = parseFloat(t.width) || 0, r = parseFloat(t.height) || 0, i = G(e), a = i ? e.offsetWidth : n, o = i ? e.offsetHeight : r, s = yt(n) !== a || yt(r) !== o;
+function yn(e) {
+	let t = W(e), n = parseFloat(t.width) || 0, r = parseFloat(t.height) || 0, i = U(e), a = i ? e.offsetWidth : n, o = i ? e.offsetHeight : r, s = St(n) !== a || St(r) !== o;
 	return s && (n = a, r = o), {
 		width: n,
 		height: r,
 		$: s
 	};
 }
-function _n(e) {
-	return W(e) ? e : e.contextElement;
+function bn(e) {
+	return H(e) ? e : e.contextElement;
 }
-function vn(e) {
-	let t = _n(e);
-	if (!G(t)) return B(1);
-	let n = t.getBoundingClientRect(), { width: r, height: i, $: a } = gn(t), o = (a ? yt(n.width) : n.width) / r, s = (a ? yt(n.height) : n.height) / i;
+function xn(e) {
+	let t = bn(e);
+	if (!U(t)) return L(1);
+	let n = t.getBoundingClientRect(), { width: r, height: i, $: a } = yn(t), o = (a ? St(n.width) : n.width) / r, s = (a ? St(n.height) : n.height) / i;
 	return (!o || !Number.isFinite(o)) && (o = 1), (!s || !Number.isFinite(s)) && (s = 1), {
 		x: o,
 		y: s
 	};
 }
-var yn = /* @__PURE__ */ B(0);
-function bn(e) {
-	let t = H(e);
-	return !un() || !t.visualViewport ? yn : {
+var Sn = /* @__PURE__ */ L(0);
+function Cn(e) {
+	let t = B(e);
+	return !pn() || !t.visualViewport ? Sn : {
 		x: t.visualViewport.offsetLeft,
 		y: t.visualViewport.offsetTop
 	};
 }
-function xn(e, t, n) {
-	return t === void 0 && (t = !1), !n || t && n !== H(e) ? !1 : t;
+function wn(e, t, n) {
+	return t === void 0 && (t = !1), !n || t && n !== B(e) ? !1 : t;
 }
-function Sn(e, t, n, r) {
+function K(e, t, n, r) {
 	t === void 0 && (t = !1), n === void 0 && (n = !1);
-	let i = e.getBoundingClientRect(), a = _n(e), o = B(1);
-	t && (r ? W(r) && (o = vn(r)) : o = vn(e));
-	let s = xn(a, n, r) ? bn(a) : B(0), c = (i.left + s.x) / o.x, l = (i.top + s.y) / o.y, u = i.width / o.x, d = i.height / o.y;
+	let i = e.getBoundingClientRect(), a = bn(e), o = L(1);
+	t && (r ? H(r) && (o = xn(r)) : o = xn(e));
+	let s = wn(a, n, r) ? Cn(a) : L(0), c = (i.left + s.x) / o.x, l = (i.top + s.y) / o.y, u = i.width / o.x, d = i.height / o.y;
 	if (a) {
-		let e = H(a), t = r && W(r) ? H(r) : r, n = e, i = hn(n);
+		let e = B(a), t = r && H(r) ? B(r) : r, n = e, i = vn(n);
 		for (; i && r && t !== n;) {
-			let e = vn(i), t = i.getBoundingClientRect(), r = q(i), a = t.left + (i.clientLeft + parseFloat(r.paddingLeft)) * e.x, o = t.top + (i.clientTop + parseFloat(r.paddingTop)) * e.y;
-			c *= e.x, l *= e.y, u *= e.x, d *= e.y, c += a, l += o, n = H(i), i = hn(n);
+			let e = xn(i), t = i.getBoundingClientRect(), r = W(i), a = t.left + (i.clientLeft + parseFloat(r.paddingLeft)) * e.x, o = t.top + (i.clientTop + parseFloat(r.paddingTop)) * e.y;
+			c *= e.x, l *= e.y, u *= e.x, d *= e.y, c += a, l += o, n = B(i), i = vn(n);
 		}
 	}
-	return Vt({
+	return Ut({
 		width: u,
 		height: d,
 		x: c,
 		y: l
 	});
 }
-function Cn(e, t) {
-	let n = fn(e).scrollLeft;
-	return t ? t.left + n : Sn(U(e)).left + n;
+function Tn(e, t) {
+	let n = hn(e).scrollLeft;
+	return t ? t.left + n : K(V(e)).left + n;
 }
-function wn(e, t) {
+function En(e, t) {
 	let n = e.getBoundingClientRect();
 	return {
-		x: n.left + t.scrollLeft - Cn(e, n),
+		x: n.left + t.scrollLeft - Tn(e, n),
 		y: n.top + t.scrollTop
 	};
 }
-function Tn(e) {
-	let { elements: t, rect: n, offsetParent: r, strategy: i } = e, a = i === "fixed", o = U(r), s = t ? rn(t.floating) : !1;
+function Dn(e) {
+	let { elements: t, rect: n, offsetParent: r, strategy: i } = e, a = i === "fixed", o = V(r), s = t ? on(t.floating) : !1;
 	if (r === o || s && a) return n;
 	let c = {
 		scrollLeft: 0,
 		scrollTop: 0
-	}, l = B(1), u = B(0), d = G(r);
-	if ((d || !d && !a) && ((Qt(r) !== "body" || tn(o)) && (c = fn(r)), d)) {
-		let e = Sn(r);
-		l = vn(r), u.x = e.x + r.clientLeft, u.y = e.y + r.clientTop;
+	}, l = L(1), u = L(0), d = U(r);
+	if ((d || !d && !a) && ((en(r) !== "body" || rn(o)) && (c = hn(r)), d)) {
+		let e = K(r);
+		l = xn(r), u.x = e.x + r.clientLeft, u.y = e.y + r.clientTop;
 	}
-	let f = o && !d && !a ? wn(o, c) : B(0);
+	let f = o && !d && !a ? En(o, c) : L(0);
 	return {
 		width: n.width * l.x,
 		height: n.height * l.y,
@@ -2092,31 +2092,31 @@ function Tn(e) {
 		y: n.y * l.y - c.scrollTop * l.y + u.y + f.y
 	};
 }
-function En(e) {
+function On(e) {
 	return Array.from(e.getClientRects());
 }
-function Dn(e) {
-	let t = U(e), n = fn(e), r = e.ownerDocument.body, i = z(t.scrollWidth, t.clientWidth, r.scrollWidth, r.clientWidth), a = z(t.scrollHeight, t.clientHeight, r.scrollHeight, r.clientHeight), o = -n.scrollLeft + Cn(e), s = -n.scrollTop;
-	return q(r).direction === "rtl" && (o += z(t.clientWidth, r.clientWidth) - i), {
+function kn(e) {
+	let t = V(e), n = hn(e), r = e.ownerDocument.body, i = xt(t.scrollWidth, t.clientWidth, r.scrollWidth, r.clientWidth), a = xt(t.scrollHeight, t.clientHeight, r.scrollHeight, r.clientHeight), o = -n.scrollLeft + Tn(e), s = -n.scrollTop;
+	return W(r).direction === "rtl" && (o += xt(t.clientWidth, r.clientWidth) - i), {
 		width: i,
 		height: a,
 		x: o,
 		y: s
 	};
 }
-var On = 25;
-function kn(e, t) {
-	let n = H(e), r = U(e), i = n.visualViewport, a = r.clientWidth, o = r.clientHeight, s = 0, c = 0;
+var An = 25;
+function jn(e, t) {
+	let n = B(e), r = V(e), i = n.visualViewport, a = r.clientWidth, o = r.clientHeight, s = 0, c = 0;
 	if (i) {
 		a = i.width, o = i.height;
-		let e = un();
+		let e = pn();
 		(!e || e && t === "fixed") && (s = i.offsetLeft, c = i.offsetTop);
 	}
-	let l = Cn(r);
+	let l = Tn(r);
 	if (l <= 0) {
 		let e = r.ownerDocument, t = e.body, n = getComputedStyle(t), i = e.compatMode === "CSS1Compat" && parseFloat(n.marginLeft) + parseFloat(n.marginRight) || 0, o = Math.abs(r.clientWidth - t.clientWidth - i);
-		o <= On && (a -= o);
-	} else l <= On && (a += l);
+		o <= An && (a -= o);
+	} else l <= An && (a += l);
 	return {
 		width: a,
 		height: o,
@@ -2124,8 +2124,8 @@ function kn(e, t) {
 		y: c
 	};
 }
-function An(e, t) {
-	let n = Sn(e, !0, t === "fixed"), r = n.top + e.clientTop, i = n.left + e.clientLeft, a = G(e) ? vn(e) : B(1);
+function Mn(e, t) {
+	let n = K(e, !0, t === "fixed"), r = n.top + e.clientTop, i = n.left + e.clientLeft, a = U(e) ? xn(e) : L(1);
 	return {
 		width: e.clientWidth * a.x,
 		height: e.clientHeight * a.y,
@@ -2133,13 +2133,13 @@ function An(e, t) {
 		y: r * a.y
 	};
 }
-function jn(e, t, n) {
+function Nn(e, t, n) {
 	let r;
-	if (t === "viewport") r = kn(e, n);
-	else if (t === "document") r = Dn(U(e));
-	else if (W(t)) r = An(t, n);
+	if (t === "viewport") r = jn(e, n);
+	else if (t === "document") r = kn(V(e));
+	else if (H(t)) r = Mn(t, n);
 	else {
-		let n = bn(e);
+		let n = Cn(e);
 		r = {
 			x: t.x - n.x,
 			y: t.y - n.y,
@@ -2147,27 +2147,27 @@ function jn(e, t, n) {
 			height: t.height
 		};
 	}
-	return Vt(r);
+	return Ut(r);
 }
-function Mn(e, t) {
-	let n = J(e);
-	return n === t || !W(n) || dn(n) ? !1 : q(n).position === "fixed" || Mn(n, t);
+function Pn(e, t) {
+	let n = G(e);
+	return n === t || !H(n) || mn(n) ? !1 : W(n).position === "fixed" || Pn(n, t);
 }
-function Nn(e, t) {
+function Fn(e, t) {
 	let n = t.get(e);
 	if (n) return n;
-	let r = mn(e, [], !1).filter((e) => W(e) && Qt(e) !== "body"), i = null, a = q(e).position === "fixed", o = a ? J(e) : e;
-	for (; W(o) && !dn(o);) {
-		let t = q(o), n = cn(o);
-		!n && t.position === "fixed" && (i = null), (a ? !n && !i : !n && t.position === "static" && i && (i.position === "absolute" || i.position === "fixed") || tn(o) && !n && Mn(e, o)) ? r = r.filter((e) => e !== o) : i = t, o = J(o);
+	let r = _n(e, [], !1).filter((e) => H(e) && en(e) !== "body"), i = null, a = W(e).position === "fixed", o = a ? G(e) : e;
+	for (; H(o) && !mn(o);) {
+		let t = W(o), n = dn(o);
+		!n && t.position === "fixed" && (i = null), (a ? !n && !i : !n && t.position === "static" && i && (i.position === "absolute" || i.position === "fixed") || rn(o) && !n && Pn(e, o)) ? r = r.filter((e) => e !== o) : i = t, o = G(o);
 	}
 	return t.set(e, r), r;
 }
-function Pn(e) {
-	let { element: t, boundary: n, rootBoundary: r, strategy: i } = e, a = [...n === "clippingAncestors" ? rn(t) ? [] : Nn(t, this._c) : [].concat(n), r], o = jn(t, a[0], i), s = o.top, c = o.right, l = o.bottom, u = o.left;
+function In(e) {
+	let { element: t, boundary: n, rootBoundary: r, strategy: i } = e, a = [...n === "clippingAncestors" ? on(t) ? [] : Fn(t, this._c) : [].concat(n), r], o = Nn(t, a[0], i), s = o.top, c = o.right, l = o.bottom, u = o.left;
 	for (let e = 1; e < a.length; e++) {
-		let n = jn(t, a[e], i);
-		s = z(n.top, s), c = vt(n.right, c), l = vt(n.bottom, l), u = z(n.left, u);
+		let n = Nn(t, a[e], i);
+		s = xt(n.top, s), c = bt(n.right, c), l = bt(n.bottom, l), u = xt(n.left, u);
 	}
 	return {
 		width: c - u,
@@ -2176,27 +2176,27 @@ function Pn(e) {
 		y: s
 	};
 }
-function Fn(e) {
-	let { width: t, height: n } = gn(e);
+function Ln(e) {
+	let { width: t, height: n } = yn(e);
 	return {
 		width: t,
 		height: n
 	};
 }
-function In(e, t, n) {
-	let r = G(t), i = U(t), a = n === "fixed", o = Sn(e, !0, a, t), s = {
+function Rn(e, t, n) {
+	let r = U(t), i = V(t), a = n === "fixed", o = K(e, !0, a, t), s = {
 		scrollLeft: 0,
 		scrollTop: 0
-	}, c = B(0);
+	}, c = L(0);
 	function l() {
-		c.x = Cn(i);
+		c.x = Tn(i);
 	}
-	if (r || !r && !a) if ((Qt(t) !== "body" || tn(i)) && (s = fn(t)), r) {
-		let e = Sn(t, !0, a, t);
+	if (r || !r && !a) if ((en(t) !== "body" || rn(i)) && (s = hn(t)), r) {
+		let e = K(t, !0, a, t);
 		c.x = e.x + t.clientLeft, c.y = e.y + t.clientTop;
 	} else i && l();
 	a && !r && i && l();
-	let u = i && !r && !a ? wn(i, s) : B(0);
+	let u = i && !r && !a ? En(i, s) : L(0);
 	return {
 		x: o.left + s.scrollLeft - c.x - u.x,
 		y: o.top + s.scrollTop - c.y - u.y,
@@ -2204,34 +2204,34 @@ function In(e, t, n) {
 		height: o.height
 	};
 }
-function Ln(e) {
-	return q(e).position === "static";
+function zn(e) {
+	return W(e).position === "static";
 }
-function Rn(e, t) {
-	if (!G(e) || q(e).position === "fixed") return null;
+function Bn(e, t) {
+	if (!U(e) || W(e).position === "fixed") return null;
 	if (t) return t(e);
 	let n = e.offsetParent;
-	return U(e) === n && (n = n.ownerDocument.body), n;
+	return V(e) === n && (n = n.ownerDocument.body), n;
 }
-function zn(e, t) {
-	let n = H(e);
-	if (rn(e)) return n;
-	if (!G(e)) {
-		let t = J(e);
-		for (; t && !dn(t);) {
-			if (W(t) && !Ln(t)) return t;
-			t = J(t);
+function Vn(e, t) {
+	let n = B(e);
+	if (on(e)) return n;
+	if (!U(e)) {
+		let t = G(e);
+		for (; t && !mn(t);) {
+			if (H(t) && !zn(t)) return t;
+			t = G(t);
 		}
 		return n;
 	}
-	let r = Rn(e, t);
-	for (; r && nn(r) && Ln(r);) r = Rn(r, t);
-	return r && dn(r) && Ln(r) && !cn(r) ? n : r || ln(e) || n;
+	let r = Bn(e, t);
+	for (; r && an(r) && zn(r);) r = Bn(r, t);
+	return r && mn(r) && zn(r) && !dn(r) ? n : r || fn(e) || n;
 }
-var Bn = async function(e) {
-	let t = this.getOffsetParent || zn, n = this.getDimensions, r = await n(e.floating);
+var Hn = async function(e) {
+	let t = this.getOffsetParent || Vn, n = this.getDimensions, r = await n(e.floating);
 	return {
-		reference: In(e.reference, await t(e.floating), e.strategy),
+		reference: Rn(e.reference, await t(e.floating), e.strategy),
 		floating: {
 			x: 0,
 			y: 0,
@@ -2240,26 +2240,26 @@ var Bn = async function(e) {
 		}
 	};
 };
-function Vn(e) {
-	return q(e).direction === "rtl";
+function Un(e) {
+	return W(e).direction === "rtl";
 }
-var Hn = {
-	convertOffsetParentRelativeRectToViewportRelativeRect: Tn,
-	getDocumentElement: U,
-	getClippingRect: Pn,
-	getOffsetParent: zn,
-	getElementRects: Bn,
-	getClientRects: En,
-	getDimensions: Fn,
-	getScale: vn,
-	isElement: W,
-	isRTL: Vn
+var Wn = {
+	convertOffsetParentRelativeRectToViewportRelativeRect: Dn,
+	getDocumentElement: V,
+	getClippingRect: In,
+	getOffsetParent: Vn,
+	getElementRects: Hn,
+	getClientRects: On,
+	getDimensions: Ln,
+	getScale: xn,
+	isElement: H,
+	isRTL: Un
 };
-function Un(e, t) {
+function Gn(e, t) {
 	return e.x === t.x && e.y === t.y && e.width === t.width && e.height === t.height;
 }
-function Wn(e, t) {
-	let n = null, r, i = U(e);
+function Kn(e, t) {
+	let n = null, r, i = V(e);
 	function a() {
 		var e;
 		clearTimeout(r), (e = n) == null || e.disconnect(), n = null;
@@ -2268,9 +2268,9 @@ function Wn(e, t) {
 		s === void 0 && (s = !1), c === void 0 && (c = 1), a();
 		let l = e.getBoundingClientRect(), { left: u, top: d, width: f, height: p } = l;
 		if (s || t(), !f || !p) return;
-		let m = bt(d), h = bt(i.clientWidth - (u + f)), g = bt(i.clientHeight - (d + p)), _ = bt(u), v = {
+		let m = Ct(d), h = Ct(i.clientWidth - (u + f)), g = Ct(i.clientHeight - (d + p)), _ = Ct(u), v = {
 			rootMargin: -m + "px " + -h + "px " + -g + "px " + -_ + "px",
-			threshold: z(0, vt(1, c)) || 1
+			threshold: xt(0, bt(1, c)) || 1
 		}, y = !0;
 		function b(t) {
 			let n = t[0].intersectionRatio;
@@ -2280,7 +2280,7 @@ function Wn(e, t) {
 					o(!1, 1e-7);
 				}, 1e3);
 			}
-			n === 1 && !Un(l, e.getBoundingClientRect()) && o(), y = !1;
+			n === 1 && !Gn(l, e.getBoundingClientRect()) && o(), y = !1;
 		}
 		try {
 			n = new IntersectionObserver(b, {
@@ -2294,13 +2294,13 @@ function Wn(e, t) {
 	}
 	return o(!0), a;
 }
-function Gn(e, t, n, r) {
+function qn(e, t, n, r) {
 	r === void 0 && (r = {});
-	let { ancestorScroll: i = !0, ancestorResize: a = !0, elementResize: o = typeof ResizeObserver == "function", layoutShift: s = typeof IntersectionObserver == "function", animationFrame: c = !1 } = r, l = _n(e), u = i || a ? [...l ? mn(l) : [], ...t ? mn(t) : []] : [];
+	let { ancestorScroll: i = !0, ancestorResize: a = !0, elementResize: o = typeof ResizeObserver == "function", layoutShift: s = typeof IntersectionObserver == "function", animationFrame: c = !1 } = r, l = bn(e), u = i || a ? [...l ? _n(l) : [], ...t ? _n(t) : []] : [];
 	u.forEach((e) => {
 		i && e.addEventListener("scroll", n, { passive: !0 }), a && e.addEventListener("resize", n);
 	});
-	let d = l && s ? Wn(l, n) : null, f = -1, p = null;
+	let d = l && s ? Kn(l, n) : null, f = -1, p = null;
 	o && (p = new ResizeObserver((e) => {
 		let [r] = e;
 		r && r.target === l && p && t && (p.unobserve(t), cancelAnimationFrame(f), f = requestAnimationFrame(() => {
@@ -2308,11 +2308,11 @@ function Gn(e, t, n, r) {
 			(e = p) == null || e.observe(t);
 		})), n();
 	}), l && !c && p.observe(l), t && p.observe(t));
-	let m, h = c ? Sn(e) : null;
+	let m, h = c ? K(e) : null;
 	c && g();
 	function g() {
-		let t = Sn(e);
-		h && !Un(h, t) && n(), h = t, m = requestAnimationFrame(g);
+		let t = K(e);
+		h && !Gn(h, t) && n(), h = t, m = requestAnimationFrame(g);
 	}
 	return n(), () => {
 		var e;
@@ -2321,19 +2321,19 @@ function Gn(e, t, n, r) {
 		}), d?.(), (e = p) == null || e.disconnect(), p = null, c && cancelAnimationFrame(m);
 	};
 }
-var Kn = Yt, qn = Xt, Jn = Kt, Yn = (e, t, n) => {
+var Jn = Zt, Yn = Qt, Xn = Jt, Zn = (e, t, n) => {
 	let r = /* @__PURE__ */ new Map(), i = {
-		platform: Hn,
+		platform: Wn,
 		...n
 	}, a = {
 		...i.platform,
 		_c: r
 	};
-	return Gt(e, t, {
+	return qt(e, t, {
 		...i,
 		platform: a
 	});
-}, Xn = o`
+}, Qn = o`
   :host {
     display: inline-block;
   }
@@ -2365,7 +2365,7 @@ var Kn = Yt, qn = Xt, Jn = Kt, Yn = (e, t, n) => {
       opacity: 0;
     }
   }
-`, Zn = [
+`, $n = [
 	"top",
 	"top-start",
 	"top-end",
@@ -2379,10 +2379,10 @@ var Kn = Yt, qn = Xt, Jn = Kt, Yn = (e, t, n) => {
 	"right-start",
 	"right-end"
 ];
-function Qn(e) {
-	return Zn.some((t) => t === e);
+function er(e) {
+	return $n.some((t) => t === e);
 }
-var $n = class e extends M {
+var tr = class e extends A {
 	constructor(...t) {
 		super(...t), this.text = "", this.placement = "top", this._open = !1, this._pointerActive = !1, this._descId = `mi-tooltip-desc-${e._idCounter++}`, this._onSlotChange = () => {
 			this.shadowRoot?.querySelector("slot")?.assignedElements().forEach((e) => e.setAttribute("aria-describedby", this._descId));
@@ -2397,7 +2397,7 @@ var $n = class e extends M {
 		}, this._handleKeyDown = (e) => {
 			e.key === "Escape" && this._open && (clearTimeout(this._hideTimer), this._open = !1, this._cleanup?.(), this._cleanup = void 0);
 		}, this._show = async () => {
-			clearTimeout(this._hideTimer), !(this._open || !this.text) && (this._open = !0, await this.updateComplete, !(!this._open || !this._tooltipEl || this._cleanup) && (this._cleanup = Gn(this, this._tooltipEl, () => this._updatePosition())));
+			clearTimeout(this._hideTimer), !(this._open || !this.text) && (this._open = !0, await this.updateComplete, !(!this._open || !this._tooltipEl || this._cleanup) && (this._cleanup = qn(this, this._tooltipEl, () => this._updatePosition())));
 		}, this._scheduleHide = () => {
 			clearTimeout(this._hideTimer), this._hideTimer = setTimeout(() => {
 				this._open = !1, this._cleanup?.(), this._cleanup = void 0;
@@ -2405,7 +2405,7 @@ var $n = class e extends M {
 		};
 	}
 	static {
-		this.styles = P(Xn);
+		this.styles = M(Qn);
 	}
 	static {
 		this._idCounter = 0;
@@ -2421,15 +2421,15 @@ var $n = class e extends M {
 	}
 	async _updatePosition() {
 		if (!this._tooltipEl) return;
-		let e = Qn(this.placement);
+		let e = er(this.placement);
 		e || console.warn(`"${this.placement}" は無効な placement 属性です。"top" を使用します。`);
-		let t = e ? this.placement : "top", { x: n, y: r } = await Yn(this, this._tooltipEl, {
+		let t = e ? this.placement : "top", { x: n, y: r } = await Zn(this, this._tooltipEl, {
 			placement: t,
 			strategy: "fixed",
 			middleware: [
-				Kn(8),
-				Jn(),
-				qn({ padding: 8 })
+				Jn(8),
+				Xn(),
+				Yn({ padding: 8 })
 			]
 		});
 		this._tooltipEl && Object.assign(this._tooltipEl.style, {
@@ -2438,19 +2438,19 @@ var $n = class e extends M {
 		});
 	}
 	render() {
-		return O`
+		return D`
       <slot @slotchange=${this._onSlotChange}></slot>
-      ${this._open ? O`<div class="tooltip" role="tooltip">${this.text}</div>` : A}
+      ${this._open ? D`<div class="tooltip" role="tooltip">${this.text}</div>` : k}
     `;
 	}
 };
-I([N({ type: String })], $n.prototype, "text", void 0), I([N({
+P([j({ type: String })], tr.prototype, "text", void 0), P([j({
 	type: String,
 	reflect: !0
-})], $n.prototype, "placement", void 0), I([Fe()], $n.prototype, "_open", void 0), I([Le(".tooltip")], $n.prototype, "_tooltipEl", void 0), customElements.get("mi-tooltip") || customElements.define("mi-tooltip", $n);
+})], tr.prototype, "placement", void 0), P([Le()], tr.prototype, "_open", void 0), P([ze(".tooltip")], tr.prototype, "_tooltipEl", void 0), customElements.get("mi-tooltip") || customElements.define("mi-tooltip", tr);
 //#endregion
 //#region src/components/button/icon-button.styles.ts
-var er = o`
+var nr = o`
   :host {
     display: inline-block;
   }
@@ -2605,25 +2605,25 @@ var er = o`
       --background-color-active: #d5dfff;
     }
   }
-`, tr = [
+`, rr = [
 	"primary",
 	"secondary",
 	"tertiary",
 	"ghost"
-], nr = [
+], ir = [
 	"small",
 	"medium",
 	"large"
-], rr = class extends R {
+], q = class extends I {
 	constructor(...e) {
 		super(...e), this.variant = "ghost", this.size = "medium", this.label = "", this.tooltipPlacement = "top", this.tooltipDisabled = !1;
 	}
 	static {
-		this.styles = P(er);
+		this.styles = M(nr);
 	}
 	static {
 		this.shadowRootOptions = {
-			...M.shadowRootOptions,
+			...A.shadowRootOptions,
 			delegatesFocus: !0
 		};
 	}
@@ -2644,61 +2644,61 @@ var er = o`
 		].filter(Boolean).join(" ");
 	}
 	renderSlot() {
-		return A;
+		return k;
 	}
 	render() {
-		let e = this.renderContent(), t = this.isLink ? O`
+		let e = this.renderContent(), t = this.isLink ? D`
           <a
             class="${this.buttonClasses}"
-            href="${this.isDisabled ? A : this.href}"
-            target="${this.target || A}"
-            rel="${this.effectiveRel || A}"
-            aria-label="${this.label || A}"
-            title="${this.tooltipDisabled && this.label ? this.label : A}"
-            aria-disabled="${this.isDisabled ? "true" : A}"
-            aria-busy="${this.loading ? "true" : A}"
+            href="${this.isDisabled ? k : this.href}"
+            target="${this.target || k}"
+            rel="${this.effectiveRel || k}"
+            aria-label="${this.label || k}"
+            title="${this.tooltipDisabled && this.label ? this.label : k}"
+            aria-disabled="${this.isDisabled ? "true" : k}"
+            aria-busy="${this.loading ? "true" : k}"
             @click="${this.handleLinkClick}"
           >
             ${e}
           </a>
-        ` : O`
+        ` : D`
           <button
             class="${this.buttonClasses}"
             ?disabled="${this.disabled}"
-            name="${this.name || A}"
-            value="${this.value || A}"
+            name="${this.name || k}"
+            value="${this.value || k}"
             type="${this.type}"
-            aria-label="${this.label || A}"
-            title="${this.tooltipDisabled && this.label ? this.label : A}"
-            aria-disabled="${this.loading ? "true" : A}"
-            aria-pressed="${this.toggle ? this.selected ? "true" : "false" : A}"
-            aria-busy="${this.loading ? "true" : A}"
+            aria-label="${this.label || k}"
+            title="${this.tooltipDisabled && this.label ? this.label : k}"
+            aria-disabled="${this.loading ? "true" : k}"
+            aria-pressed="${this.toggle ? this.selected ? "true" : "false" : k}"
+            aria-busy="${this.loading ? "true" : k}"
             @click="${this.handleClick}"
           >
             ${e}
           </button>
         `;
-		return !this.label || this.tooltipDisabled ? t : O`
+		return !this.label || this.tooltipDisabled ? t : D`
       <mi-tooltip text="${this.label}" placement="${this.tooltipPlacement}">
         ${t}
       </mi-tooltip>
     `;
 	}
 };
-I([N({ type: String })], rr.prototype, "variant", void 0), I([N({ type: String })], rr.prototype, "size", void 0), I([N({
+P([j({ type: String })], q.prototype, "variant", void 0), P([j({ type: String })], q.prototype, "size", void 0), P([j({
 	type: String,
 	attribute: "aria-label",
 	reflect: !0
-})], rr.prototype, "label", void 0), I([N({
+})], q.prototype, "label", void 0), P([j({
 	type: String,
 	attribute: "tooltip-placement"
-})], rr.prototype, "tooltipPlacement", void 0), I([N({
+})], q.prototype, "tooltipPlacement", void 0), P([j({
 	type: Boolean,
 	attribute: "tooltip-disabled"
-})], rr.prototype, "tooltipDisabled", void 0), customElements.get("mi-icon-button") || customElements.define("mi-icon-button", rr);
+})], q.prototype, "tooltipDisabled", void 0), customElements.get("mi-icon-button") || customElements.define("mi-icon-button", q);
 //#endregion
 //#region src/components/button/mi-neutral-button.ts
-var ir = class extends R {
+var ar = class extends I {
 	constructor(...e) {
 		super(...e), this.danger = !1, this.variants = null, this.variant = "primary";
 	}
@@ -2706,21 +2706,21 @@ var ir = class extends R {
 		return this.danger ? "danger" : "normal";
 	}
 	getEffectiveVariant() {
-		let e = this.variants == null ? this.variant : this.variants, t = pt(e);
-		return t || console.warn(`${e}は無効なvariant属性です。`), t ? e : dt[0];
+		let e = this.variants == null ? this.variant : this.variants, t = ht(e);
+		return t || console.warn(`${e}は無効なvariant属性です。`), t ? e : pt[0];
 	}
 };
-I([N({
+P([j({
 	type: Boolean,
 	reflect: !0
-})], ir.prototype, "danger", void 0), I([N({ type: String })], ir.prototype, "variants", void 0), I([N({ type: String })], ir.prototype, "variant", void 0);
-var ar = class extends ir {}, or = class extends ar {};
-customElements.get("mi-neutral-button") || customElements.define("mi-neutral-button", ir), customElements.get("mi-button") || customElements.define("mi-button", ar), customElements.get("sp-button") || customElements.define("sp-button", or);
+})], ar.prototype, "danger", void 0), P([j({ type: String })], ar.prototype, "variants", void 0), P([j({ type: String })], ar.prototype, "variant", void 0);
+var or = class extends ar {}, sr = class extends or {};
+customElements.get("mi-neutral-button") || customElements.define("mi-neutral-button", ar), customElements.get("mi-button") || customElements.define("mi-button", or), customElements.get("sp-button") || customElements.define("sp-button", sr);
 //#endregion
 //#region src/components/checkbox/checkbox.css?inline
-var sr = ":host{display:inline-block}.checkmark:has(.input:focus-visible):before{box-shadow:0 0 0 2px #fff,0 0 0 4px #191919}.base:hover .checkmark:has(:not(.input:disabled)):before{border-color:#0000008a;outline:4px solid #0000000a}.base:active .checkmark:has(:not(.input:disabled)):before{outline:4px solid #00000012}.base:hover:active .checkmark:has(:not(.input:disabled)):before{outline:4px solid #00000012}.base:hover .checkmark:has(:is(.input:checked,.input:indeterminate)):has(:not(.input:disabled)):before{background-color:#2666bf;border-color:#2666bf}", cr = ".checkmark{cursor:pointer;flex-grow:0;flex-shrink:0;padding-block:4px;padding-inline:4px;display:inline-flex}.checkmark:before{content:\"\";background:#fff 50% no-repeat;border:1.5px solid #0000004a;border-radius:2px;width:16px;height:16px;display:inline-block}.checkmark:has(:is(.input:checked,.input:indeterminate)):before{background-color:#3f69f2;border-color:#3f69f2}.checkmark:has(.input:checked):before{background-image:url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMTIuNDE0MSA2LjIwNzAzTDYuNzA3MDMgMTEuOTE0MUwzIDguMjA3MDNMNC40MTQwNiA2Ljc5Mjk3TDYuNzA3MDMgOS4wODU5NEwxMSA0Ljc5Mjk3TDEyLjQxNDEgNi4yMDcwM1oiIGZpbGw9IndoaXRlIi8+PC9zdmc+)}.checkmark:has(.input:indeterminate):before{background-image:url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMTIgN1Y5SDRWN0gxMloiIGZpbGw9IndoaXRlIi8+PC9zdmc+)}.checkmark:has(.input:disabled){cursor:not-allowed}.checkmark:has(.input:disabled):before{background-color:#e5e5e5;border-color:#0000000d}.checkmark .input{z-index:-1;opacity:0;position:absolute}", Y = class extends M {
+var cr = ":host{display:inline-block}.checkmark:has(.input:focus-visible):before{box-shadow:0 0 0 2px #fff,0 0 0 4px #191919}.base:hover .checkmark:has(:not(.input:disabled)):before{border-color:#0000008a;outline:4px solid #0000000a}.base:active .checkmark:has(:not(.input:disabled)):before{outline:4px solid #00000012}.base:hover:active .checkmark:has(:not(.input:disabled)):before{outline:4px solid #00000012}.base:hover .checkmark:has(:is(.input:checked,.input:indeterminate)):has(:not(.input:disabled)):before{background-color:#2666bf;border-color:#2666bf}", lr = ".checkmark{cursor:pointer;flex-grow:0;flex-shrink:0;padding-block:4px;padding-inline:4px;display:inline-flex}.checkmark:before{content:\"\";background:#fff 50% no-repeat;border:1.5px solid #0000004a;border-radius:2px;width:16px;height:16px;display:inline-block}.checkmark:has(:is(.input:checked,.input:indeterminate)):before{background-color:#3f69f2;border-color:#3f69f2}.checkmark:has(.input:checked):before{background-image:url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMTIuNDE0MSA2LjIwNzAzTDYuNzA3MDMgMTEuOTE0MUwzIDguMjA3MDNMNC40MTQwNiA2Ljc5Mjk3TDYuNzA3MDMgOS4wODU5NEwxMSA0Ljc5Mjk3TDEyLjQxNDEgNi4yMDcwM1oiIGZpbGw9IndoaXRlIi8+PC9zdmc+)}.checkmark:has(.input:indeterminate):before{background-image:url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTYiIGhlaWdodD0iMTYiIHZpZXdCb3g9IjAgMCAxNiAxNiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cGF0aCBkPSJNMTIgN1Y5SDRWN0gxMloiIGZpbGw9IndoaXRlIi8+PC9zdmc+)}.checkmark:has(.input:disabled){cursor:not-allowed}.checkmark:has(.input:disabled):before{background-color:#e5e5e5;border-color:#0000000d}.checkmark .input{z-index:-1;opacity:0;position:absolute}", J = class extends A {
 	static {
-		this.styles = P(a(cr), a(sr));
+		this.styles = M(a(lr), a(cr));
 	}
 	static {
 		this.formAssociated = !0;
@@ -2743,7 +2743,7 @@ var sr = ":host{display:inline-block}.checkmark:has(.input:focus-visible):before
 		}));
 	}
 	render() {
-		return O`
+		return D`
       <label class="base">
         <span class="checkmark">
           <input
@@ -2761,29 +2761,29 @@ var sr = ":host{display:inline-block}.checkmark:has(.input:focus-visible):before
     `;
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0
-})], Y.prototype, "value", void 0), I([N({
+})], J.prototype, "value", void 0), P([j({
 	type: String,
 	reflect: !0
-})], Y.prototype, "name", void 0), I([N({
+})], J.prototype, "name", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], Y.prototype, "checked", void 0), I([N({
+})], J.prototype, "checked", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], Y.prototype, "indeterminate", void 0), I([N({
+})], J.prototype, "indeterminate", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], Y.prototype, "disabled", void 0);
-var lr = class extends Y {};
-customElements.get("mi-checkbox") || customElements.define("mi-checkbox", Y), customElements.get("sp-checkbox") || customElements.define("sp-checkbox", lr);
+})], J.prototype, "disabled", void 0);
+var ur = class extends J {};
+customElements.get("mi-checkbox") || customElements.define("mi-checkbox", J), customElements.get("sp-checkbox") || customElements.define("sp-checkbox", ur);
 //#endregion
 //#region src/components/checkbox/checkbox-text.css?inline
-var ur = ":host{max-width:100%;display:inline-block}.base{cursor:pointer;justify-content:flex-start;align-items:flex-start;max-width:100%;display:inline-flex}.checkmark:has(.input:focus-visible):before{box-shadow:0 0 0 2px #fff,0 0 0 4px #191919}.base:has(.input:disabled){cursor:not-allowed}.text{color:#000000d6;letter-spacing:.02em;padding-block:3px;padding-inline:4px;font-size:14px;line-height:1.3}.base:has(.input:disabled) .text{color:#00000059}.base:hover .checkmark:has(:not(.input:disabled)):before{border-color:#0000008a;outline:4px solid #0000000a}.base:active .checkmark:has(:not(.input:disabled)):before{outline:4px solid #00000012}.base:hover:active .checkmark:has(:not(.input:disabled)):before{outline:4px solid #00000012}.base:hover .checkmark:has(:is(.input:checked,.input:indeterminate)):has(:not(.input:disabled)):before{background-color:#2666bf;border-color:#2666bf}", X = class extends M {
+var dr = ":host{max-width:100%;display:inline-block}.base{cursor:pointer;justify-content:flex-start;align-items:flex-start;max-width:100%;display:inline-flex}.checkmark:has(.input:focus-visible):before{box-shadow:0 0 0 2px #fff,0 0 0 4px #191919}.base:has(.input:disabled){cursor:not-allowed}.text{color:#000000d6;letter-spacing:.02em;padding-block:3px;padding-inline:4px;font-size:14px;line-height:1.3}.base:has(.input:disabled) .text{color:#00000059}.base:hover .checkmark:has(:not(.input:disabled)):before{border-color:#0000008a;outline:4px solid #0000000a}.base:active .checkmark:has(:not(.input:disabled)):before{outline:4px solid #00000012}.base:hover:active .checkmark:has(:not(.input:disabled)):before{outline:4px solid #00000012}.base:hover .checkmark:has(:is(.input:checked,.input:indeterminate)):has(:not(.input:disabled)):before{background-color:#2666bf;border-color:#2666bf}", Y = class extends A {
 	static {
-		this.styles = P(a(cr), a(ur));
+		this.styles = M(a(lr), a(dr));
 	}
 	static {
 		this.formAssociated = !0;
@@ -2806,7 +2806,7 @@ var ur = ":host{max-width:100%;display:inline-block}.base{cursor:pointer;justify
 		}));
 	}
 	render() {
-		return O`
+		return D`
       <label class="base">
         <span class="checkmark">
           <input
@@ -2825,30 +2825,155 @@ var ur = ":host{max-width:100%;display:inline-block}.base{cursor:pointer;justify
     `;
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0
-})], X.prototype, "value", void 0), I([N({
+})], Y.prototype, "value", void 0), P([j({
 	type: String,
 	reflect: !0
-})], X.prototype, "name", void 0), I([N({
+})], Y.prototype, "name", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], X.prototype, "checked", void 0), I([N({
+})], Y.prototype, "checked", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], X.prototype, "indeterminate", void 0), I([N({
+})], Y.prototype, "indeterminate", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], X.prototype, "disabled", void 0), I([N({
+})], Y.prototype, "disabled", void 0), P([j({
 	type: String,
 	reflect: !0
-})], X.prototype, "text", void 0);
-var dr = class extends X {};
-customElements.get("mi-checkbox-text") || customElements.define("mi-checkbox-text", X), customElements.get("sp-checkbox-text") || customElements.define("sp-checkbox-text", dr);
+})], Y.prototype, "text", void 0);
+var fr = class extends Y {};
+customElements.get("mi-checkbox-text") || customElements.define("mi-checkbox-text", Y), customElements.get("sp-checkbox-text") || customElements.define("sp-checkbox-text", fr);
+//#endregion
+//#region src/components/chip/input-chip.styles.ts
+var pr = o`
+  :host {
+    display: inline-block;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    max-width: 100%;
+    padding-inline-start: var(--spacing-large, 12px);
+    padding-inline-end: var(--spacing-small, 4px);
+    padding-block: 2px;
+    min-block-size: 28px;
+    border-radius: 9999px;
+    background-color: #e8edff;
+    box-sizing: border-box;
+  }
+
+  .label {
+    font-size: 12px;
+    font-weight: normal;
+    line-height: 1.5;
+    letter-spacing: 0.12px;
+    color: var(--text-regular-default, rgba(0, 0, 0, 0.84));
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+
+  @media (max-width: 720px) {
+    .chip {
+      min-block-size: 32px;
+    }
+
+    .label {
+      font-size: var(--font-scale-40, 14px);
+      letter-spacing: 0.14px;
+    }
+  }
+`, mr = class extends A {
+	constructor(...e) {
+		super(...e), this.label = "";
+	}
+	static {
+		this.styles = M(pr);
+	}
+	render() {
+		return D`
+      <span class="chip">
+        <span class="label">${this.label}</span>
+        <mi-icon-button
+          variant="ghost"
+          size="small"
+          icon-type="cross-small"
+          aria-label="${this.label}を削除"
+          tooltip-disabled
+          @click="${this.handleRemove}"
+        ></mi-icon-button>
+      </span>
+    `;
+	}
+	handleRemove() {
+		this.dispatchEvent(new CustomEvent("remove", {
+			bubbles: !1,
+			composed: !1
+		}));
+	}
+};
+P([j({ type: String })], mr.prototype, "label", void 0), customElements.get("mi-input-chip") || customElements.define("mi-input-chip", mr);
+//#endregion
+//#region src/components/chip/input-chip-group.styles.ts
+var hr = o`
+  :host {
+    display: block;
+  }
+
+  .container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: flex-start;
+    align-content: flex-start;
+  }
+
+  .item {
+    flex: 0 1 auto;
+    max-width: 100%;
+    min-width: 0;
+  }
+`, gr = class extends A {
+	constructor(...e) {
+		super(...e), this.items = [];
+	}
+	static {
+		this.styles = M(hr);
+	}
+	render() {
+		return D`
+      <div class="container" role="list">
+        ${this.items.map((e) => D`
+            <div class="item" role="listitem">
+              <mi-input-chip
+                label=${e.label}
+                @remove=${() => this.handleRemove(e.id)}
+              ></mi-input-chip>
+            </div>
+          `)}
+      </div>
+    `;
+	}
+	handleRemove(e) {
+		this.dispatchEvent(new CustomEvent("remove", {
+			bubbles: !1,
+			composed: !1,
+			detail: { id: e }
+		}));
+	}
+};
+P([j({ type: Array })], gr.prototype, "items", void 0), customElements.get("mi-input-chip-group") || customElements.define("mi-input-chip-group", gr);
 //#endregion
 //#region src/components/dialog/dialog.styles.ts
-var fr = [a(".dialog-root::backdrop{background:var(--neutral-neutral-50-alpha,#0000004a)}"), o`
+var _r = [a(".dialog-root::backdrop{background:var(--neutral-neutral-50-alpha,#0000004a)}"), o`
     /* ========== Dialog ルート ========== */
     .dialog-root {
       border: none;
@@ -3073,7 +3198,7 @@ var fr = [a(".dialog-root::backdrop{background:var(--neutral-neutral-50-alpha,#0
         padding: var(--spacing-x-large, 16px);
       }
     }
-  `], Z = class extends M {
+  `], X = class extends A {
 	constructor(...e) {
 		super(...e), this.open = !1, this.headerText = "", this.cancelLabel = "", this.actionLabel = "", this.danger = !1, this.formId = "", this._isScrolledFromTop = !1, this._isScrolledFromBottom = !1, this._closingFromFooterButton = !1, this._boundCheckScroll = () => this._checkScroll(), this._handleClose = () => {
 			if (this._closingFromFooterButton) {
@@ -3104,7 +3229,7 @@ var fr = [a(".dialog-root::backdrop{background:var(--neutral-neutral-50-alpha,#0
 		};
 	}
 	static {
-		this.styles = P(...fr);
+		this.styles = M(..._r);
 	}
 	get sizeClass() {
 		return `size-${this.dialogSize}`;
@@ -3131,13 +3256,13 @@ var fr = [a(".dialog-root::backdrop{background:var(--neutral-neutral-50-alpha,#0
 		return this.renderRoot.querySelector("dialog");
 	}
 	render() {
-		return this.open ? O`
+		return this.open ? D`
       <dialog
         class="dialog-root"
         @close=${this._handleClose}
         role="dialog"
         aria-modal="true"
-        aria-labelledby=${this.headerText ? "dialog-title" : A}
+        aria-labelledby=${this.headerText ? "dialog-title" : k}
         aria-describedby="dialog-body"
       >
         <div
@@ -3151,11 +3276,11 @@ var fr = [a(".dialog-root::backdrop{background:var(--neutral-neutral-50-alpha,#0
             data-variant=${this.variant}
             data-testid="dialog-popup"
           >
-            ${this.headerText ? O`
+            ${this.headerText ? D`
                   <header class="header" data-testid="dialog-header">
                     <h2 id="dialog-title" class="title">${this.headerText}</h2>
                   </header>
-                ` : A}
+                ` : k}
             <div
               class="body"
               id="dialog-body"
@@ -3166,7 +3291,7 @@ var fr = [a(".dialog-root::backdrop{background:var(--neutral-neutral-50-alpha,#0
               <slot></slot>
             </div>
             <footer class="footer" data-testid="dialog-footer">
-              ${this.cancelLabel ? O`
+              ${this.cancelLabel ? D`
                     <mi-neutral-button
                       class="footer-action"
                       variant="ghost"
@@ -3175,25 +3300,25 @@ var fr = [a(".dialog-root::backdrop{background:var(--neutral-neutral-50-alpha,#0
                     >
                       ${this.cancelLabel}
                     </mi-neutral-button>
-                  ` : A}
-              ${this.danger ? O`
+                  ` : k}
+              ${this.danger ? D`
                     <mi-danger-button
                       class="footer-action"
                       variant="primary"
                       size="large"
                       type=${this.actionButtonType}
-                      form=${this.formId || A}
+                      form=${this.formId || k}
                       @click=${this._handleActionClick}
                     >
                       ${this.actionLabel}
                     </mi-danger-button>
-                  ` : O`
+                  ` : D`
                     <mi-neutral-button
                       class="footer-action"
                       variant="primary"
                       size="large"
                       type=${this.actionButtonType}
-                      form=${this.formId || A}
+                      form=${this.formId || k}
                       @click=${this._handleActionClick}
                     >
                       ${this.actionLabel}
@@ -3203,31 +3328,31 @@ var fr = [a(".dialog-root::backdrop{background:var(--neutral-neutral-50-alpha,#0
           </div>
         </div>
       </dialog>
-    ` : A;
+    ` : k;
 	}
 };
-I([N({
+P([j({
 	type: Boolean,
 	reflect: !0
-})], Z.prototype, "open", void 0), I([N({
+})], X.prototype, "open", void 0), P([j({
 	type: String,
 	attribute: "header-text"
-})], Z.prototype, "headerText", void 0), I([N({
+})], X.prototype, "headerText", void 0), P([j({
 	type: String,
 	attribute: "cancel-label"
-})], Z.prototype, "cancelLabel", void 0), I([N({
+})], X.prototype, "cancelLabel", void 0), P([j({
 	type: String,
 	attribute: "action-label"
-})], Z.prototype, "actionLabel", void 0), I([N({
+})], X.prototype, "actionLabel", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], Z.prototype, "danger", void 0), I([N({
+})], X.prototype, "danger", void 0), P([j({
 	type: String,
 	attribute: "form-id"
-})], Z.prototype, "formId", void 0), I([Le(".body")], Z.prototype, "_bodyEl", void 0), I([Fe()], Z.prototype, "_isScrolledFromTop", void 0), I([Fe()], Z.prototype, "_isScrolledFromBottom", void 0);
+})], X.prototype, "formId", void 0), P([ze(".body")], X.prototype, "_bodyEl", void 0), P([Le()], X.prototype, "_isScrolledFromTop", void 0), P([Le()], X.prototype, "_isScrolledFromBottom", void 0);
 //#endregion
 //#region src/components/dialog/mi-action-dialog.ts
-var pr = class extends Z {
+var vr = class extends X {
 	get dialogSize() {
 		return "small";
 	}
@@ -3235,23 +3360,23 @@ var pr = class extends Z {
 		return "action";
 	}
 };
-customElements.get("mi-action-dialog") || customElements.define("mi-action-dialog", pr);
+customElements.get("mi-action-dialog") || customElements.define("mi-action-dialog", vr);
 //#endregion
 //#region src/components/dialog/mi-form-dialog.ts
-var mr = [
+var yr = [
 	"small",
 	"medium",
 	"large"
 ];
-function hr(e) {
-	return mr.includes(e);
+function br(e) {
+	return yr.includes(e);
 }
-var gr = class extends Z {
+var xr = class extends X {
 	constructor(...e) {
 		super(...e), this.size = "medium";
 	}
 	get dialogSize() {
-		let e = hr(this.size);
+		let e = br(this.size);
 		return e || console.warn(`"${this.size}" は無効な size 属性です。"medium" を使用します。`), e ? this.size : "medium";
 	}
 	get variant() {
@@ -3261,35 +3386,35 @@ var gr = class extends Z {
 		return this.formId ? "submit" : "button";
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0
-})], gr.prototype, "size", void 0), customElements.get("mi-form-dialog") || customElements.define("mi-form-dialog", gr);
+})], xr.prototype, "size", void 0), customElements.get("mi-form-dialog") || customElements.define("mi-form-dialog", xr);
 //#endregion
 //#region src/components/dialog/mi-information-dialog.ts
-var _r = ["small", "medium"];
-function vr(e) {
-	return _r.includes(e);
+var Sr = ["small", "medium"];
+function Cr(e) {
+	return Sr.includes(e);
 }
-var yr = class extends Z {
+var wr = class extends X {
 	constructor(...e) {
 		super(...e), this.size = "medium";
 	}
 	get dialogSize() {
-		let e = vr(this.size);
+		let e = Cr(this.size);
 		return e || console.warn(`"${this.size}" は無効な size 属性です。"medium" を使用します。`), e ? this.size : "medium";
 	}
 	get variant() {
 		return "information";
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0
-})], yr.prototype, "size", void 0), customElements.get("mi-information-dialog") || customElements.define("mi-information-dialog", yr);
+})], wr.prototype, "size", void 0), customElements.get("mi-information-dialog") || customElements.define("mi-information-dialog", wr);
 //#endregion
 //#region src/components/floating-button/floating-button.styles.ts
-var br = o`
+var Tr = o`
   :host {
     display: inline-block;
     --color-primary-red-90: #f72a48;
@@ -3367,30 +3492,30 @@ var br = o`
     font-size: 25px;
     fill: var(--color-primary-red-90);
   }
-`, xr = class extends M {
+`, Er = class extends A {
 	constructor(...e) {
 		super(...e), this.loading = !1;
 	}
 	static {
-		this.styles = P(br);
+		this.styles = M(Tr);
 	}
 	render() {
-		return O`<button class="base">
-      ${this.loading ? O`<mi-loading class="loading" ai size="3xLarge"></mi-loading>` : O`<mi-icon class="icon" type="magic-fill"></mi-icon>`}
+		return D`<button class="base">
+      ${this.loading ? D`<mi-loading class="loading" ai size="3xLarge"></mi-loading>` : D`<mi-icon class="icon" type="magic-fill"></mi-icon>`}
     </button>`;
 	}
 };
-I([N({ type: Boolean })], xr.prototype, "loading", void 0);
-var Sr = class extends xr {};
-customElements.get("mi-floating-button") || customElements.define("mi-floating-button", xr), customElements.get("sp-floating-button") || customElements.define("sp-floating-button", Sr);
+P([j({ type: Boolean })], Er.prototype, "loading", void 0);
+var Dr = class extends Er {};
+customElements.get("mi-floating-button") || customElements.define("mi-floating-button", Er), customElements.get("sp-floating-button") || customElements.define("sp-floating-button", Dr);
 //#endregion
 //#region src/components/icon-color/icon-color.css?inline
-var Cr = ":host{width:1.28em;height:1.28em;display:inline-block}.icon-color{width:100%;height:100%}", wr = [
+var Or = ":host{width:1.28em;height:1.28em;display:inline-block}.icon-color{width:100%;height:100%}", kr = [
 	"error",
 	"information",
 	"success",
 	"warning"
-], Tr = {
+], Ar = {
 	error: "<rect x=\"6\" y=\"6\" width=\"12\" height=\"12\" fill=\"white\"/><path d=\"M21.28 7.845L16.15 2.715C16.01 2.575 15.82 2.495 15.62 2.495H8.37C8.17 2.495 7.98 2.575 7.84 2.715L2.72 7.845C2.58 7.985 2.5 8.175 2.5 8.375V15.625C2.5 15.825 2.58 16.015 2.72 16.155L7.85 21.285C7.99 21.425 8.18 21.505 8.38 21.505H15.63C15.83 21.505 16.02 21.425 16.16 21.285L21.29 16.155C21.43 16.015 21.51 15.825 21.51 15.625V8.375C21.51 8.175 21.43 7.985 21.29 7.845H21.28ZM16.81 15.745L15.75 16.805L12 13.055L8.25 16.805L7.19 15.745L10.94 11.995L7.19 8.245L8.25 7.185L12 10.935L15.75 7.185L16.81 8.245L13.06 11.995L16.81 15.745Z\" fill=\"#C92812\"/>",
 	information: "<rect x=\"6\" y=\"5\" width=\"12\" height=\"14\" fill=\"white\"/><path d=\"M12 2C6.49 2 2 6.49 2 12C2 17.51 6.49 22 12 22C17.51 22 22 17.51 22 12C22 6.49 17.51 2 12 2ZM12.75 16.86H11.25V10.36H12.75V16.86ZM12.83 8.86H11.17V7.14H12.83V8.86Z\" fill=\"#315CE8\"/>",
 	success: "<rect x=\"6\" y=\"5\" width=\"12\" height=\"14\" fill=\"white\"/><path d=\"M12 2.02002C6.49 2.02002 2 6.51002 2 12.02C2 17.53 6.49 22.02 12 22.02C17.51 22.02 22 17.53 22 12.02C22 6.51002 17.52 2.02002 12 2.02002ZM10.83 15.5L7.22 11.9L8.28 10.84L10.83 13.38L15.73 8.49002L16.79 9.55002L10.83 15.49V15.5Z\" fill=\"#00783C\"/>",
@@ -3398,34 +3523,34 @@ var Cr = ":host{width:1.28em;height:1.28em;display:inline-block}.icon-color{widt
 };
 //#endregion
 //#region src/components/icon-color/index.ts
-function Er(e) {
-	return wr.includes(e);
+function jr(e) {
+	return kr.includes(e);
 }
-var Dr = class extends M {
+var Mr = class extends A {
 	constructor(...e) {
 		super(...e), this.type = "information";
 	}
 	static {
-		this.styles = P(a(Cr));
+		this.styles = M(a(Or));
 	}
 	render() {
-		return Er(this.type) ? O`<svg
+		return jr(this.type) ? D`<svg
         class="icon-color"
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
         aria-hidden="true"
       >
-        ${We(Tr[this.type])}
-      </svg>` : O``;
+        ${Ke(Ar[this.type])}
+      </svg>` : D``;
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0
-})], Dr.prototype, "type", void 0), customElements.get("mi-icon-color") || customElements.define("mi-icon-color", Dr);
+})], Mr.prototype, "type", void 0), customElements.get("mi-icon-color") || customElements.define("mi-icon-color", Mr);
 //#endregion
 //#region src/components/inline-notification/inline-notification.styles.ts
-var Or = o`
+var Nr = o`
   .base {
     display: flex;
     align-items: flex-start;
@@ -3458,21 +3583,21 @@ var Or = o`
     width: 20px;
     height: 20px;
   }
-`, kr = [
+`, Pr = [
 	"information",
 	"success",
 	"warning",
 	"error"
-], Ar = class extends M {
+], Fr = class extends A {
 	constructor(...e) {
 		super(...e), this.type = "information";
 	}
 	static {
-		this.styles = P(Or);
+		this.styles = M(Nr);
 	}
 	render() {
-		let e = kr.includes(this.type) ? this.type : "information";
-		return O`
+		let e = Pr.includes(this.type) ? this.type : "information";
+		return D`
       <div class="base" data-type=${e}>
         <mi-icon-color class="icon" type=${e}></mi-icon-color>
         <div><slot></slot></div>
@@ -3480,15 +3605,15 @@ var Or = o`
     `;
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0
-})], Ar.prototype, "type", void 0), customElements.get("mi-inline-notification") || customElements.define("mi-inline-notification", Ar);
+})], Fr.prototype, "type", void 0), customElements.get("mi-inline-notification") || customElements.define("mi-inline-notification", Fr);
 //#endregion
 //#region node_modules/lit-html/directives/class-map.js
-var jr = ze(class extends Be {
+var Ir = Ve(class extends He {
 	constructor(e) {
-		if (super(e), e.type !== Re.ATTRIBUTE || e.name !== "class" || e.strings?.length > 2) throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.");
+		if (super(e), e.type !== Be.ATTRIBUTE || e.name !== "class" || e.strings?.length > 2) throw Error("`classMap()` can only be used in the `class` attribute and must be the only part in the attribute.");
 	}
 	render(e) {
 		return " " + Object.keys(e).filter((t) => e[t]).join(" ") + " ";
@@ -3505,80 +3630,80 @@ var jr = ze(class extends Be {
 			let r = !!t[e];
 			r === this.st.has(e) || this.nt?.has(e) || (r ? (n.add(e), this.st.add(e)) : (n.remove(e), this.st.delete(e)));
 		}
-		return k;
+		return O;
 	}
-}), Mr = ":host{flex-direction:column;gap:4px;display:flex}:host .label{font-weight:var(--font-weight-bold);color:#000000d6;font-size:14px}:host .label.none{display:none}:host .support{font-weight:var(--font-weight-normal);color:#0000008a;font-size:12px}:host .support.none{display:none}", Nr = class extends M {
+}), Lr = ":host{flex-direction:column;gap:4px;display:flex}:host .label{font-weight:var(--font-weight-bold);color:#000000d6;font-size:14px}:host .label.none{display:none}:host .support{font-weight:var(--font-weight-normal);color:#0000008a;font-size:12px}:host .support.none{display:none}", Rr = class extends A {
 	constructor(...e) {
 		super(...e), this.text = "", this.supportText = "";
 	}
 	static {
-		this.styles = P(a(Mr));
+		this.styles = M(a(Lr));
 	}
 	isEmpty() {
 		return this.text === "" && this.supportText === "";
 	}
 	#e() {
-		return jr({
+		return Ir({
 			label: !0,
 			none: !this.text
 		});
 	}
 	#t() {
-		return jr({
+		return Ir({
 			support: !0,
 			none: !this.supportText
 		});
 	}
 	render() {
-		return O`
+		return D`
       <span class=${this.#e()}>${this.text}</span>
       <span class=${this.#t()}>${this.supportText}</span>
     `;
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0
-})], Nr.prototype, "text", void 0), I([N({
+})], Rr.prototype, "text", void 0), P([j({
 	type: String,
 	attribute: "support-text",
 	reflect: !0
-})], Nr.prototype, "supportText", void 0);
-var Pr = class extends Nr {};
-customElements.get("mi-label-unit") || customElements.define("mi-label-unit", Nr), customElements.get("sp-label-unit") || customElements.define("sp-label-unit", Pr);
+})], Rr.prototype, "supportText", void 0);
+var zr = class extends Rr {};
+customElements.get("mi-label-unit") || customElements.define("mi-label-unit", Rr), customElements.get("sp-label-unit") || customElements.define("sp-label-unit", zr);
 //#endregion
 //#region src/components/logo/constants.ts
-var Fr = "Speeda", Ir = "Uzabase", Lr = "<svg viewBox=\"0 0 74 26\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n<g clip-path=\"url(#clip0_10_438)\">\n<path d=\"M0.812012 1.2381V24.7619C0.812012 25.4457 1.36633 26 2.05011 26H57.9432C58.6067 26 59.2198 25.646 59.5516 25.0714L73.1687 1.48571C73.5499 0.825395 73.0734 0 72.3109 0H2.05011C1.36633 0 0.812012 0.554314 0.812012 1.2381Z\" fill=\"#F72A48\"/>\n<path d=\"M10.5969 17.5256C10.0161 17.8902 9.39656 18.2299 8.73824 18.5363C8.73805 18.5364 8.73787 18.5365 8.73767 18.5365C8.73767 18.5366 8.73768 18.5365 8.73767 18.5365L7.3739 16.5267C10.5202 15.1267 12.7216 13.069 13.7984 10.8079H8.36688V8.63046L16.9291 8.63047C16.6076 10.614 15.8557 12.3764 14.6848 13.9237C15.874 14.7334 17.1438 15.6717 18.2251 16.6103L16.6578 18.68C15.5557 17.6134 14.371 16.6055 13.1394 15.6214C12.395 16.3092 11.547 16.9436 10.5969 17.5256ZM31.8955 12.1251V14.533H39.9379L41.3298 12.1251H31.8955ZM53.7827 6.56189L53.3408 8.28962H54.8604L55.3012 6.56189H53.7827ZM51.3513 6.56189L50.9106 8.28962H52.4302L52.871 6.56189H51.3513ZM45.9291 18.9428L44.4946 16.9455C45.9176 16.5384 47.1377 15.9168 48.1075 15.1511C47.3533 14.4926 46.5161 13.8469 45.7377 13.2968C45.3318 13.667 44.9005 14.0141 44.4104 14.337L42.8305 12.7583C44.8763 11.2625 45.9776 9.51546 46.6234 7.63808L48.9448 8.21119C48.849 8.48682 48.7406 8.77393 48.6219 9.06111H53.4553C53.1748 13.532 50.8371 17.2615 45.9291 18.9428ZM50.6549 11.1668H47.5205C47.4018 11.3467 47.2061 11.6216 47.0746 11.8014C47.8634 12.2673 48.7623 12.9547 49.588 13.6132C50.0908 12.8832 50.5119 11.9683 50.6549 11.1668ZM22.8732 14.9699V13.8051C25.3258 13.5538 27.7066 13.1231 29.3577 12.6924L28.8911 10.3953C27.0367 10.9576 24.7994 11.3405 22.8971 11.5798C22.9091 10.6346 22.921 8.98122 22.945 8.03607L20.5402 8.63047V15.7356C20.5402 18.272 21.7246 18.5113 24.7755 18.5113C26.0436 18.5113 28.257 18.4874 29.3457 18.4275V16.1424C28.3527 16.2022 25.936 16.286 24.6797 16.286C23.1842 16.286 22.8732 16.2022 22.8732 14.9699ZM30.7542 8.25709C30.7542 9.19336 29.9953 9.95229 29.059 9.95229C28.1228 9.95229 27.3638 9.19336 27.3638 8.25709C27.3638 7.32087 28.1228 6.56189 29.059 6.56189C29.9953 6.56189 30.7542 7.32087 30.7542 8.25709ZM29.9006 8.25709C29.9006 7.79235 29.5238 7.41554 29.059 7.41554C28.5943 7.41554 28.2175 7.79235 28.2175 8.25709C28.2175 8.7219 28.5943 9.09863 29.059 9.09863C29.5238 9.09863 29.9006 8.7219 29.9006 8.25709Z\" fill=\"white\"/>\n</g>\n<defs>\n<clipPath id=\"clip0_10_438\">\n<rect width=\"72.4909\" height=\"26\" fill=\"white\" transform=\"translate(0.812012)\"/>\n</clipPath>\n</defs>\n</svg>\n", Rr = "<svg viewBox=\"0 0 74 26\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n<path d=\"M72.1973 0H1.9354C1.25055 0 0.697144 0.556428 0.697144 1.23822V24.7618C0.697144 25.4466 1.25055 26 1.9354 26H57.8275C58.491 26 59.1055 25.6454 59.4357 25.0706L73.0533 1.48589C73.4355 0.82548 72.9585 0 72.1973 0Z\" fill=\"#F72A48\"/>\n<path d=\"M13.1507 10.0632C12.9506 9.80871 12.6891 9.60628 12.3665 9.45625C12.0436 9.30623 11.7323 9.23123 11.4323 9.23123C11.2776 9.23123 11.1207 9.24486 10.9618 9.27214C10.8026 9.29942 10.6594 9.35184 10.5322 9.42899C10.4047 9.50633 10.298 9.60628 10.2117 9.72902C10.1252 9.85175 10.0821 10.0086 10.0821 10.1995C10.0821 10.3632 10.1162 10.4996 10.1844 10.6087C10.2526 10.7178 10.3525 10.8132 10.4844 10.8951C10.6161 10.9769 10.773 11.0519 10.9549 11.1201C11.1367 11.1883 11.3413 11.2588 11.5687 11.3315C11.896 11.4406 12.2369 11.5612 12.5915 11.6929C12.9461 11.8248 13.2687 11.9998 13.5598 12.218C13.8507 12.4362 14.0917 12.7068 14.2826 13.0294C14.4736 13.3523 14.569 13.7546 14.569 14.2364C14.569 14.7911 14.4667 15.2708 14.2622 15.6752C14.0576 16.0799 13.7825 16.414 13.4371 16.6776C13.0914 16.9414 12.6959 17.1368 12.2506 17.2641C11.805 17.3913 11.3457 17.455 10.8731 17.455C10.1821 17.455 9.51379 17.3344 8.86833 17.0936C8.22263 16.8528 7.68629 16.5095 7.25903 16.0639L8.7865 14.5092C9.02284 14.8003 9.33414 15.0434 9.72071 15.2388C10.107 15.4344 10.4913 15.532 10.8731 15.532C11.0457 15.532 11.2141 15.5139 11.3777 15.4775C11.5414 15.4412 11.6846 15.382 11.8073 15.3002C11.9301 15.2183 12.0277 15.1092 12.1006 14.9729C12.1732 14.8365 12.2097 14.6728 12.2097 14.4819C12.2097 14.3001 12.164 14.1456 12.0733 14.0182C11.9823 13.891 11.8527 13.7751 11.6846 13.6704C11.5163 13.566 11.3072 13.4705 11.0572 13.384C10.8071 13.2977 10.523 13.2046 10.2048 13.1044C9.89565 13.0045 9.59327 12.8862 9.29794 12.7499C9.00237 12.6135 8.73875 12.4385 8.5069 12.2248C8.27505 12.0113 8.08859 11.7521 7.94777 11.4474C7.80671 11.1429 7.73636 10.7723 7.73636 10.3359C7.73636 9.79955 7.84547 9.34034 8.06367 8.95847C8.28189 8.57661 8.5683 8.26292 8.92289 8.01745C9.27748 7.77196 9.67746 7.59253 10.123 7.47874C10.5684 7.36517 11.0185 7.30826 11.4732 7.30826C12.0187 7.30826 12.5755 7.40842 13.1439 7.6083C13.712 7.8084 14.2098 8.10396 14.6372 8.49477L13.1507 10.0632ZM22.97 12.4304C22.8217 11.9978 22.6086 11.6177 22.3304 11.2902C22.0524 10.9627 21.7125 10.7032 21.314 10.5147C20.9123 10.3232 20.4674 10.2274 19.9761 10.2274C19.4786 10.2274 19.043 10.3293 18.6753 10.5332C18.3076 10.7372 18.0171 10.9782 17.8101 11.2501H17.7668V10.4189H15.6411V20.5717L17.8781 20.0186V16.4594H17.9059C18.1129 16.7499 18.4034 16.9785 18.7772 17.1484C19.1511 17.3153 19.5466 17.4018 19.9637 17.4018C20.4736 17.4018 20.9277 17.2998 21.3263 17.099C21.7279 16.9013 22.0648 16.6355 22.3428 16.3018C22.6209 15.9713 22.831 15.5881 22.9793 15.1494C23.1245 14.7137 23.1956 14.2595 23.1956 13.7868C23.1956 13.314 23.1214 12.8598 22.97 12.4304ZM20.9247 14.4356C20.8566 14.6488 20.7578 14.8373 20.6249 15.001C20.492 15.1648 20.3283 15.2946 20.1275 15.3965C19.9267 15.4954 19.6949 15.5448 19.4323 15.5448C19.1758 15.5448 18.9503 15.4954 18.7494 15.3965C18.5486 15.2946 18.3787 15.1648 18.2397 15.001C18.0975 14.8373 17.9894 14.6488 17.9121 14.4418C17.8349 14.2317 17.7947 14.0185 17.7947 13.7991C17.7947 13.5829 17.8349 13.3697 17.9121 13.1595C17.9894 12.9495 18.0975 12.764 18.2397 12.6003C18.3787 12.4365 18.5486 12.3037 18.7494 12.2048C18.9503 12.1029 19.1758 12.0534 19.4323 12.0534C19.6949 12.0534 19.9267 12.1029 20.1275 12.2048C20.3283 12.3037 20.492 12.4335 20.6249 12.5941C20.7578 12.7517 20.8566 12.9371 20.9247 13.1441C20.9926 13.3542 21.0266 13.5674 21.0266 13.7868C21.0266 14.003 20.9926 14.2193 20.9247 14.4356ZM31.1612 13.8954V14.1682C31.1612 14.2592 31.1565 14.3455 31.1476 14.4273H26.2242C26.2424 14.6183 26.2992 14.7911 26.3947 14.9456C26.4902 15.1003 26.6129 15.2343 26.7629 15.3479C26.913 15.4617 27.0811 15.5503 27.2676 15.6138C27.4538 15.6776 27.6471 15.7093 27.8472 15.7093C28.2017 15.7093 28.5018 15.6435 28.7473 15.5115C28.9928 15.3799 29.1926 15.2094 29.3473 15.0001L30.9021 15.9821C30.5837 16.4458 30.1633 16.8027 29.6406 17.0527C29.1176 17.3026 28.5108 17.4277 27.8199 17.4277C27.3106 17.4277 26.8288 17.348 26.3743 17.189C25.9195 17.0301 25.5219 16.7982 25.1809 16.4935C24.84 16.189 24.5717 15.8139 24.3763 15.3684C24.1807 14.923 24.0831 14.4137 24.0831 13.8409C24.0831 13.2864 24.1785 12.7839 24.3695 12.3339C24.5604 11.8838 24.8195 11.502 25.1468 11.1883C25.4742 10.8746 25.8605 10.6315 26.3061 10.4587C26.7514 10.2861 27.2335 10.1995 27.7517 10.1995C28.2516 10.1995 28.7108 10.2837 29.1291 10.4518C29.5472 10.6202 29.9065 10.8633 30.2065 11.1815C30.5066 11.4998 30.7406 11.8862 30.9089 12.3407C31.0771 12.7954 31.1612 13.3137 31.1612 13.8954ZM29.1019 13.0362C29.1019 12.6817 28.9904 12.3771 28.7677 12.1225C28.5448 11.8681 28.2107 11.7406 27.7654 11.7406C27.5471 11.7406 27.347 11.7747 27.1653 11.8429C26.9833 11.9111 26.8243 12.0044 26.6879 12.1225C26.5515 12.2408 26.4424 12.3795 26.3606 12.5385C26.2788 12.6976 26.2332 12.8636 26.2242 13.0362H29.1019ZM39.153 13.8954V14.1682C39.153 14.2592 39.1483 14.3455 39.1394 14.4273H34.2161C34.2342 14.6183 34.2911 14.7911 34.3865 14.9456C34.482 15.1003 34.6047 15.2343 34.7548 15.3479C34.9048 15.4617 35.0729 15.5503 35.2594 15.6138C35.4456 15.6776 35.6389 15.7093 35.839 15.7093C36.1936 15.7093 36.4936 15.6435 36.7391 15.5115C36.9846 15.3799 37.1845 15.2094 37.3392 15.0001L38.8939 15.9821C38.5755 16.4458 38.1551 16.8027 37.6324 17.0527C37.1094 17.3026 36.5025 17.4277 35.8117 17.4277C35.3024 17.4277 34.8206 17.348 34.3661 17.189C33.9113 17.0301 33.5137 16.7982 33.1728 16.4935C32.8318 16.189 32.5635 15.8139 32.3681 15.3684C32.1725 14.923 32.0749 14.4137 32.0749 13.8409C32.0749 13.2864 32.1703 12.7839 32.3613 12.3339C32.5522 11.8838 32.8113 11.502 33.1387 11.1883C33.4659 10.8746 33.8523 10.6315 34.2979 10.4587C34.7432 10.2861 35.2253 10.1995 35.7435 10.1995C36.2434 10.1995 36.7027 10.2837 37.121 10.4518C37.5391 10.6202 37.8983 10.8633 38.1984 11.1815C38.4984 11.4998 38.7324 11.8862 38.9007 12.3407C39.0688 12.7954 39.153 13.3137 39.153 13.8954ZM37.0937 13.0362C37.0937 12.6817 36.9823 12.3771 36.7596 12.1225C36.5366 11.8681 36.2025 11.7406 35.7571 11.7406C35.5389 11.7406 35.3388 11.7747 35.1571 11.8429C34.9751 11.9111 34.8161 12.0044 34.6798 12.1225C34.5434 12.2408 34.4343 12.3795 34.3524 12.5385C34.2706 12.6976 34.225 12.8636 34.2161 13.0362H37.0937ZM45.3733 7.11546V11.1419H45.3454C45.1539 10.9133 44.8851 10.7032 44.5391 10.5147C44.193 10.3232 43.7728 10.2274 43.2722 10.2274C42.7809 10.2274 42.336 10.3232 41.9406 10.5147C41.545 10.7032 41.2114 10.9627 40.9333 11.2902C40.6552 11.6177 40.442 11.9978 40.2906 12.4304C40.1423 12.8598 40.0682 13.314 40.0682 13.7868C40.0682 14.2595 40.1392 14.7137 40.2845 15.1494C40.4297 15.5881 40.6428 15.9713 40.9179 16.3018C41.1959 16.6355 41.5358 16.9013 41.9344 17.099C42.336 17.2998 42.7903 17.4018 43.3001 17.4018C43.7542 17.4018 44.1837 17.306 44.5885 17.1206C44.9932 16.9352 45.3022 16.6695 45.5216 16.3235H45.5494V17.2103H47.6072V6.56238L45.3733 7.11546ZM45.3516 14.4418C45.2744 14.6488 45.1663 14.8373 45.0242 15.001C44.882 15.1648 44.712 15.2946 44.5112 15.3965C44.3135 15.4954 44.0849 15.5448 43.8315 15.5448C43.5657 15.5448 43.334 15.4954 43.1363 15.3965C42.9354 15.2946 42.7655 15.1648 42.6296 15.001C42.4936 14.8373 42.3917 14.6488 42.3237 14.4356C42.2557 14.2193 42.2217 14.003 42.2217 13.7868C42.2217 13.5674 42.2557 13.3542 42.3237 13.1441C42.3917 12.9371 42.4936 12.7517 42.6296 12.5941C42.7655 12.4335 42.9354 12.3037 43.1363 12.2048C43.334 12.1029 43.5657 12.0534 43.8315 12.0534C44.0849 12.0534 44.3135 12.1029 44.5112 12.2048C44.712 12.3037 44.882 12.4365 45.0242 12.6003C45.1663 12.764 45.2744 12.9495 45.3516 13.1595C45.4289 13.3697 45.466 13.5829 45.466 13.7991C45.466 14.0185 45.4289 14.2317 45.3516 14.4418ZM49.0353 11.3451C49.4352 10.9633 49.9013 10.6769 50.4331 10.4859C50.965 10.295 51.5082 10.1995 52.0629 10.1995C52.6357 10.1995 53.1199 10.2701 53.5153 10.4109C53.9108 10.552 54.2313 10.7702 54.4768 11.0655C54.7223 11.3611 54.9017 11.7338 55.0155 12.1839C55.1291 12.6339 55.186 13.1681 55.186 13.7863V17.2095H53.1403V16.4867H53.0994C52.9266 16.7686 52.6651 16.9868 52.3152 17.1413C51.9651 17.2958 51.5856 17.3731 51.1764 17.3731C50.9037 17.3731 50.6217 17.3367 50.3309 17.2641C50.0398 17.1914 49.7738 17.0731 49.533 16.9095C49.292 16.7458 49.0943 16.5276 48.9398 16.2548C48.7851 15.9821 48.7079 15.6458 48.7079 15.2456C48.7079 14.7546 48.842 14.3591 49.1102 14.0591C49.3783 13.7591 49.724 13.5272 50.1467 13.3636C50.5695 13.1999 51.04 13.0908 51.5583 13.0362C52.0765 12.9817 52.5811 12.9544 53.0721 12.9544V12.8453C53.0721 12.5091 52.9538 12.2612 52.7175 12.102C52.481 11.9431 52.1901 11.8634 51.8447 11.8634C51.5263 11.8634 51.2195 11.9316 50.9241 12.0679C50.6286 12.2043 50.3763 12.368 50.1672 12.5589L49.0353 11.3451ZM53.1403 14.25H52.8539C52.6084 14.25 52.3606 14.2615 52.1106 14.2841C51.8604 14.3069 51.6378 14.3502 51.4423 14.4137C51.2467 14.4774 51.0854 14.5705 50.9582 14.6933C50.8308 14.816 50.7673 14.9775 50.7673 15.1774C50.7673 15.3049 50.7967 15.414 50.8559 15.5047C50.9149 15.5957 50.99 15.6684 51.081 15.7229C51.1717 15.7775 51.2764 15.8163 51.3946 15.8389C51.5127 15.8617 51.6265 15.873 51.7356 15.873C52.1901 15.873 52.5379 15.7481 52.7789 15.4979C53.0197 15.248 53.1403 14.9093 53.1403 14.4819V14.25Z\" fill=\"white\"/>\n</svg>\n", zr = "<svg viewBox=\"0 0 134 20\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n<g clip-path=\"url(#clip0_10_447)\">\n<path d=\"M1.04199 0V3.126H2.08399V10.418H19.168V0H1.04199ZM4.74999 2.292H9.47999V4.272H4.74999V2.292ZM4.74999 6.146H9.47999V8.126H4.74999V6.146ZM16.5 8.124H11.77V6.144H16.5V8.124ZM16.5 4.27H11.77V2.29H16.5V4.27Z\" fill=\"#191919\"/>\n<path d=\"M15.088 11.876L16.892 15H19.538L17.734 11.876H15.088Z\" fill=\"#191919\"/>\n<path d=\"M15.404 15L13.6 11.876H10.954L12.758 15H15.404Z\" fill=\"#191919\"/>\n<path d=\"M2.76 20L4.77 12.5H2.01L0 20H2.76Z\" fill=\"#191919\"/>\n<path d=\"M17.708 16.584V17.416H8.49998V14.374H9.41598V12.5H5.83398V18.124L7.70798 20H18.958L20.834 18.124V16.584H17.708Z\" fill=\"#191919\"/>\n<path d=\"M68.86 7.99L68.51 8.342L62.266 14.584H65.802L70.276 10.108L74.752 14.584H78.288L71.36 7.658V6.042H75.944V3.75H71.36V1.874H72.278V0H68.86V3.75H64.278V6.042H68.86V7.99Z\" fill=\"#191919\"/>\n<path d=\"M62.17 3.124L59.046 0H55.804L58.93 3.124H62.17Z\" fill=\"#191919\"/>\n<path d=\"M75.152 17.416H62.482L60.986 14.824V5H56.194V7.5H58.278V15.6L53.876 20H57.412L59.742 17.67L61.088 20H61.946H76.402L78.278 18.126V16.584H75.152V17.416Z\" fill=\"#191919\"/>\n<path d=\"M28.53 14.584L30.186 8.40601H27.426L25.77 14.584H28.53Z\" fill=\"#191919\"/>\n<path d=\"M40.352 0.00201416H32.91L30.788 2.29401H38.228L40.352 0.00201416Z\" fill=\"#191919\"/>\n<path d=\"M45.142 17.418H36.186V12.722L46.196 2.71H48.268V0H45.166L36.186 8.98V5.874H37.102V4H33.478V11.688L29.056 16.11V16.114H29.052L25.166 20H28.908L33.478 15.43V18.126L35.352 20H46.392L48.268 18.126V16.584H45.142V17.418Z\" fill=\"#191919\"/>\n<path d=\"M47.434 14.584L45.76 8.33398H43L44.674 14.584H47.434Z\" fill=\"#191919\"/>\n<path d=\"M91.754 7.952C91.568 7.716 91.326 7.528 91.026 7.388C90.726 7.248 90.438 7.18 90.16 7.18C90.016 7.18 89.87 7.192 89.724 7.218C89.576 7.244 89.444 7.292 89.326 7.364C89.208 7.436 89.108 7.528 89.028 7.642C88.948 7.756 88.908 7.902 88.908 8.078C88.908 8.23 88.94 8.356 89.002 8.458C89.066 8.56 89.158 8.648 89.28 8.724C89.402 8.8 89.548 8.87 89.716 8.932C89.884 8.996 90.074 9.06 90.286 9.128C90.59 9.23 90.906 9.342 91.236 9.464C91.566 9.586 91.864 9.748 92.134 9.952C92.404 10.154 92.628 10.406 92.804 10.706C92.982 11.006 93.07 11.378 93.07 11.826C93.07 12.34 92.976 12.786 92.786 13.162C92.596 13.538 92.34 13.848 92.02 14.092C91.7 14.336 91.332 14.518 90.918 14.636C90.504 14.754 90.078 14.814 89.64 14.814C88.998 14.814 88.378 14.702 87.78 14.478C87.18 14.254 86.684 13.936 86.286 13.522L87.704 12.08C87.924 12.35 88.212 12.576 88.57 12.758C88.928 12.94 89.286 13.03 89.64 13.03C89.8 13.03 89.956 13.014 90.108 12.98C90.26 12.946 90.392 12.892 90.506 12.816C90.62 12.74 90.71 12.638 90.778 12.512C90.846 12.386 90.88 12.234 90.88 12.056C90.88 11.878 90.838 11.744 90.754 11.626C90.67 11.508 90.55 11.4 90.394 11.304C90.238 11.208 90.044 11.118 89.812 11.038C89.58 10.958 89.316 10.872 89.022 10.778C88.736 10.686 88.454 10.576 88.18 10.448C87.906 10.322 87.662 10.16 87.446 9.96C87.23 9.762 87.058 9.522 86.928 9.238C86.798 8.956 86.732 8.612 86.732 8.206C86.732 7.708 86.834 7.282 87.036 6.928C87.238 6.574 87.504 6.282 87.834 6.054C88.164 5.826 88.534 5.66 88.948 5.554C89.362 5.448 89.778 5.396 90.2 5.396C90.706 5.396 91.222 5.488 91.75 5.674C92.278 5.86 92.74 6.134 93.136 6.496L91.756 7.952H91.754Z\" fill=\"#191919\"/>\n<path d=\"M101.434 10.148C101.296 9.746 101.098 9.394 100.84 9.09C100.582 8.786 100.266 8.546 99.896 8.37C99.524 8.192 99.11 8.104 98.654 8.104C98.198 8.104 97.788 8.198 97.446 8.388C97.104 8.578 96.836 8.8 96.644 9.054H96.604V8.282H94.632V17.704L96.708 17.19V13.888H96.734C96.926 14.158 97.196 14.37 97.542 14.528C97.888 14.682 98.256 14.764 98.644 14.764C99.118 14.764 99.538 14.67 99.908 14.484C100.28 14.3 100.594 14.054 100.852 13.744C101.11 13.438 101.306 13.082 101.442 12.674C101.576 12.27 101.642 11.848 101.642 11.41C101.642 10.972 101.574 10.55 101.432 10.152L101.434 10.148ZM99.536 12.008C99.472 12.206 99.382 12.38 99.258 12.532C99.134 12.684 98.982 12.804 98.796 12.9C98.61 12.992 98.394 13.038 98.15 13.038C97.906 13.038 97.702 12.992 97.516 12.9C97.33 12.806 97.172 12.684 97.042 12.532C96.91 12.38 96.81 12.206 96.738 12.014C96.666 11.82 96.63 11.622 96.63 11.418C96.63 11.214 96.668 11.02 96.738 10.824C96.81 10.63 96.91 10.456 97.042 10.306C97.172 10.154 97.328 10.03 97.516 9.938C97.702 9.844 97.912 9.798 98.15 9.798C98.388 9.798 98.608 9.844 98.796 9.938C98.982 10.03 99.134 10.15 99.258 10.3C99.382 10.446 99.474 10.618 99.536 10.81C99.6 11.004 99.63 11.202 99.63 11.406C99.63 11.61 99.598 11.808 99.536 12.008Z\" fill=\"#191919\"/>\n<path d=\"M109.6 11.508V11.762C109.6 11.846 109.596 11.926 109.588 12.002H105.02C105.036 12.18 105.09 12.34 105.178 12.482C105.266 12.626 105.38 12.75 105.52 12.856C105.66 12.962 105.816 13.044 105.988 13.102C106.16 13.162 106.34 13.19 106.526 13.19C106.856 13.19 107.134 13.128 107.362 13.006C107.59 12.884 107.776 12.726 107.918 12.532L109.36 13.444C109.064 13.874 108.674 14.206 108.19 14.438C107.704 14.67 107.142 14.786 106.5 14.786C106.028 14.786 105.58 14.712 105.158 14.564C104.736 14.416 104.368 14.202 104.05 13.918C103.734 13.636 103.484 13.288 103.304 12.874C103.122 12.46 103.032 11.988 103.032 11.456C103.032 10.924 103.12 10.476 103.298 10.058C103.476 9.63999 103.716 9.28599 104.02 8.99399C104.324 8.70199 104.682 8.47799 105.096 8.31599C105.51 8.15599 105.956 8.07599 106.438 8.07599C106.92 8.07599 107.328 8.15399 107.716 8.30999C108.104 8.46599 108.438 8.69199 108.716 8.98799C108.994 9.28399 109.212 9.64199 109.368 10.064C109.524 10.486 109.602 10.966 109.602 11.506L109.6 11.508ZM107.69 10.71C107.69 10.38 107.586 10.098 107.38 9.86199C107.174 9.62599 106.864 9.50799 106.45 9.50799C106.248 9.50799 106.062 9.53999 105.894 9.60199C105.726 9.66599 105.578 9.75199 105.452 9.86199C105.326 9.97199 105.224 10.1 105.148 10.248C105.072 10.396 105.03 10.55 105.022 10.71H107.692H107.69Z\" fill=\"#191919\"/>\n<path d=\"M117.584 11.508V11.762C117.584 11.846 117.58 11.926 117.572 12.002H113.004C113.02 12.18 113.074 12.34 113.162 12.482C113.25 12.626 113.364 12.75 113.504 12.856C113.644 12.962 113.8 13.044 113.972 13.102C114.144 13.162 114.324 13.19 114.51 13.19C114.84 13.19 115.118 13.128 115.346 13.006C115.574 12.884 115.76 12.726 115.902 12.532L117.344 13.444C117.048 13.874 116.658 14.206 116.174 14.438C115.688 14.67 115.126 14.786 114.484 14.786C114.012 14.786 113.564 14.712 113.142 14.564C112.72 14.416 112.352 14.202 112.034 13.918C111.718 13.636 111.468 13.288 111.288 12.874C111.106 12.46 111.016 11.988 111.016 11.456C111.016 10.924 111.104 10.476 111.282 10.058C111.46 9.63999 111.7 9.28599 112.004 8.99399C112.308 8.70199 112.666 8.47799 113.08 8.31599C113.494 8.15599 113.94 8.07599 114.422 8.07599C114.904 8.07599 115.312 8.15399 115.7 8.30999C116.088 8.46599 116.422 8.69199 116.7 8.98799C116.978 9.28399 117.196 9.64199 117.352 10.064C117.508 10.486 117.586 10.966 117.586 11.506L117.584 11.508ZM115.672 10.71C115.672 10.38 115.568 10.098 115.362 9.86199C115.156 9.62599 114.846 9.50799 114.432 9.50799C114.23 9.50799 114.044 9.53999 113.876 9.60199C113.708 9.66599 113.56 9.75199 113.434 9.86199C113.308 9.97199 113.206 10.1 113.13 10.248C113.054 10.396 113.012 10.55 113.004 10.71H115.674H115.672Z\" fill=\"#191919\"/>\n<path d=\"M123.924 5.216V8.952H123.898C123.72 8.74 123.47 8.544 123.15 8.37C122.828 8.192 122.438 8.104 121.974 8.104C121.51 8.104 121.106 8.192 120.738 8.37C120.37 8.544 120.062 8.786 119.804 9.09C119.546 9.394 119.348 9.746 119.208 10.148C119.07 10.546 119.002 10.968 119.002 11.406C119.002 11.844 119.068 12.266 119.202 12.67C119.336 13.078 119.534 13.432 119.79 13.74C120.048 14.05 120.364 14.296 120.734 14.48C121.106 14.666 121.528 14.76 122.002 14.76C122.424 14.76 122.822 14.672 123.198 14.5C123.574 14.328 123.86 14.082 124.064 13.76H124.09V14.582H126V4.702L123.928 5.216H123.924ZM123.902 12.014C123.83 12.206 123.73 12.382 123.598 12.532C123.466 12.684 123.308 12.804 123.122 12.9C122.938 12.992 122.726 13.038 122.492 13.038C122.246 13.038 122.03 12.992 121.846 12.9C121.66 12.806 121.502 12.684 121.376 12.532C121.25 12.38 121.156 12.206 121.092 12.008C121.028 11.808 120.998 11.606 120.998 11.406C120.998 11.206 121.03 11.004 121.092 10.81C121.156 10.618 121.25 10.446 121.376 10.3C121.502 10.15 121.66 10.03 121.846 9.938C122.03 9.844 122.244 9.798 122.492 9.798C122.74 9.798 122.94 9.844 123.122 9.938C123.308 10.03 123.466 10.154 123.598 10.306C123.73 10.458 123.83 10.63 123.902 10.824C123.974 11.018 124.008 11.216 124.008 11.418C124.008 11.62 123.974 11.82 123.902 12.014Z\" fill=\"#191919\"/>\n<path d=\"M127.888 9.13999C128.26 8.78599 128.692 8.51999 129.186 8.34199C129.68 8.16399 130.184 8.07599 130.698 8.07599C131.212 8.07599 131.678 8.14199 132.046 8.27199C132.412 8.40199 132.71 8.60599 132.938 8.87999C133.166 9.15399 133.332 9.49999 133.438 9.91799C133.544 10.336 133.596 10.832 133.596 11.406V14.582H131.698V13.912H131.66C131.5 14.174 131.256 14.376 130.932 14.52C130.608 14.664 130.254 14.736 129.876 14.736C129.622 14.736 129.362 14.702 129.092 14.634C128.822 14.566 128.576 14.456 128.352 14.304C128.128 14.152 127.944 13.95 127.802 13.696C127.658 13.442 127.586 13.13 127.586 12.76C127.586 12.304 127.71 11.938 127.96 11.658C128.208 11.38 128.53 11.164 128.922 11.012C129.314 10.86 129.75 10.758 130.232 10.708C130.712 10.658 131.182 10.632 131.636 10.632V10.53C131.636 10.218 131.526 9.98799 131.306 9.83999C131.086 9.69199 130.816 9.61799 130.496 9.61799C130.2 9.61799 129.916 9.68199 129.642 9.80799C129.368 9.93399 129.134 10.086 128.94 10.264L127.89 9.13799L127.888 9.13999ZM131.698 11.836H131.432C131.204 11.836 130.974 11.846 130.742 11.868C130.51 11.89 130.304 11.93 130.122 11.988C129.94 12.048 129.79 12.134 129.672 12.248C129.554 12.362 129.494 12.512 129.494 12.698C129.494 12.816 129.522 12.918 129.576 13.002C129.63 13.086 129.7 13.154 129.784 13.204C129.868 13.254 129.966 13.29 130.076 13.312C130.186 13.334 130.292 13.344 130.392 13.344C130.814 13.344 131.136 13.228 131.36 12.996C131.584 12.764 131.696 12.45 131.696 12.054V11.838L131.698 11.836Z\" fill=\"#191919\"/>\n</g>\n<defs>\n<clipPath id=\"clip0_10_447\">\n<rect width=\"133.596\" height=\"20\" fill=\"white\"/>\n</clipPath>\n</defs>\n</svg>\n", Br = "<svg viewBox=\"0 0 118 19\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n<g clip-path=\"url(#clip0_2813_53)\">\n<path d=\"M10.2549 0.167748H9.8355C8.91288 0.167748 8.57739 0.475856 8.57739 1.39676V13.4386C8.57739 15.1435 7.54351 16.2613 5.75649 16.2613C3.96946 16.2613 2.90649 15.1435 2.90649 13.4386V1.39676C2.90649 0.474144 2.59838 0.167748 1.67748 0.167748H1.25811C0.335496 0.167748 0 0.474144 0 1.39676V13.4386C0 15.1144 0.530631 16.4564 1.5936 17.4629C2.65487 18.4694 4.05162 18.9726 5.75649 18.9726C7.46135 18.9726 8.82901 18.4694 9.89198 17.4629C10.9532 16.429 11.4856 15.0887 11.4856 13.4386V1.39676C11.4856 0.474144 11.1775 0.167748 10.2566 0.167748H10.2549ZM27.4644 16.15H20.787L27.437 5.05811C27.9403 4.24847 28.1919 3.43712 28.1919 2.60009V1.53883C28.1919 0.504955 27.8838 0.169459 26.8499 0.169459H19.6128C18.6902 0.169459 18.3838 0.477568 18.3838 1.39847V1.6227C18.3838 2.54532 18.6919 2.85171 19.6128 2.85171H25.4241L18.8014 13.9436C18.2708 14.7259 18.0192 15.5646 18.0192 16.4581V17.4646C18.0192 18.4985 18.3547 18.834 19.3886 18.834H27.4627C28.3853 18.834 28.6917 18.5259 28.6917 17.605V17.3807C28.6917 16.4581 28.3836 16.1517 27.4627 16.1517L27.4644 16.15ZM43.195 1.50973C42.9434 0.475856 42.5532 0.167748 41.5193 0.167748H39.4806C38.4468 0.167748 38.0565 0.475856 37.8049 1.50973L34.1726 17.6032C33.9484 18.4968 34.2565 18.8323 35.1791 18.8323H35.6532C36.6306 18.8323 36.9661 18.5806 37.1904 17.6032L37.8049 14.7532H43.1968L43.8404 17.6032C44.0355 18.5806 44.371 18.8323 45.3484 18.8323H45.8516C46.7742 18.8323 47.0532 18.4968 46.829 17.6032L43.1968 1.50973H43.195ZM38.3886 12.0984L38.9192 9.64036C39.5611 6.65 40.0643 3.85649 40.4563 1.31459C40.7079 2.90649 41.2386 5.67261 42.0773 9.66946L42.6079 12.1001H38.3886V12.0984ZM61.8869 9.24838C63.4514 8.82901 64.5127 7.6 64.5127 5.39189V4.77739C64.5127 1.98387 62.5562 0.167748 59.0078 0.167748H54.6498C53.6159 0.167748 53.2805 0.503243 53.2805 1.53712V17.4629C53.2805 18.4968 53.6159 18.8323 54.6498 18.8323H59.2595C62.9191 18.8323 65.016 16.8758 65.016 13.8871V13.2726C65.016 10.842 63.8143 9.50171 61.8869 9.25009V9.24838ZM56.1596 2.79351H58.9257C60.6853 2.79351 61.6644 3.60315 61.6644 5.02901V5.58703C61.6644 7.17892 60.9096 8.10153 58.6741 8.10153H56.1596V2.79351ZM62.1386 13.7194C62.1386 15.2565 61.1047 16.2065 58.9805 16.2065H56.1578V10.6742H59.0078C61.103 10.6742 62.1369 11.513 62.1369 13.1887V13.7194H62.1386ZM79.9078 1.50973C79.6562 0.475856 79.266 0.167748 78.2321 0.167748H76.1934C75.1596 0.167748 74.7693 0.475856 74.5177 1.50973L70.8854 17.6032C70.6612 18.4968 70.9693 18.8323 71.8919 18.8323H72.366C73.3434 18.8323 73.6789 18.5806 73.9032 17.6032L74.5177 14.7532H79.9096L80.5532 17.6032C80.7483 18.5806 81.0838 18.8323 82.0612 18.8323H82.5644C83.487 18.8323 83.766 18.4968 83.5418 17.6032L79.9096 1.50973H79.9078ZM75.1014 12.0984L75.632 9.64036C76.2739 6.65 76.7771 3.85649 77.1691 1.31459C77.4207 2.90649 77.9514 5.67261 78.7901 9.66946L79.3207 12.1001H75.1014V12.0984ZM95.2191 7.99027C93.5707 7.23541 92.2578 6.25802 92.2578 4.91604C92.2578 3.49189 93.2078 2.65315 94.7997 2.65315C96.4755 2.65315 97.5094 3.60315 97.5933 5.08378C97.6771 5.86604 98.0126 6.09027 98.9061 6.09027H99.3255C100.192 6.09027 100.5 5.78216 100.5 5.02901C100.5 3.54838 99.9691 2.34676 98.9352 1.42414C97.9014 0.474144 96.532 0 94.8271 0C93.2352 0 91.8932 0.474144 90.8594 1.39676C89.8255 2.31937 89.2949 3.51928 89.2949 5.00162C89.2384 8.43874 92.3691 9.83549 94.7433 10.8129C96.419 11.5113 97.7336 12.5177 97.7336 13.8854C97.7336 15.4225 96.6433 16.316 94.9401 16.316C93.0401 16.316 91.9224 15.1983 91.8385 13.7177C91.7546 12.9354 91.4465 12.6838 90.553 12.6838H90.1062C89.2966 12.6838 88.9046 13.0193 88.9046 13.6903C88.9046 15.2548 89.4626 16.5403 90.6095 17.5177C91.7546 18.495 93.1805 18.9709 94.9401 18.9709C96.6997 18.9709 98.0691 18.4968 99.103 17.5468C100.137 16.5968 100.667 15.3386 100.667 13.8032C100.695 10.45 97.6224 8.99847 95.2191 7.99198V7.99027ZM115.811 2.85C116.734 2.85 117.04 2.54189 117.04 1.62099V1.39676C117.04 0.474144 116.732 0.167748 115.811 0.167748H108.909C107.876 0.167748 107.54 0.503243 107.54 1.53712V17.4629C107.54 18.4968 107.876 18.8323 108.909 18.8323H115.811C116.734 18.8323 117.04 18.5241 117.04 17.6032V17.379C117.04 16.4564 116.732 16.15 115.811 16.15H110.419V10.842H115.226C116.148 10.842 116.427 10.563 116.427 9.58387V9.35964C116.427 8.43703 116.148 8.13063 115.226 8.13063H110.419V2.85H115.811Z\" fill=\"black\"/>\n</g>\n<defs>\n<clipPath id=\"clip0_2813_53\">\n<rect width=\"117.081\" height=\"19\" fill=\"white\"/>\n</clipPath>\n</defs>\n</svg>\n", Vr = class extends M {
+var Br = "Speeda", Vr = "Uzabase", Hr = "<svg viewBox=\"0 0 74 26\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n<g clip-path=\"url(#clip0_10_438)\">\n<path d=\"M0.812012 1.2381V24.7619C0.812012 25.4457 1.36633 26 2.05011 26H57.9432C58.6067 26 59.2198 25.646 59.5516 25.0714L73.1687 1.48571C73.5499 0.825395 73.0734 0 72.3109 0H2.05011C1.36633 0 0.812012 0.554314 0.812012 1.2381Z\" fill=\"#F72A48\"/>\n<path d=\"M10.5969 17.5256C10.0161 17.8902 9.39656 18.2299 8.73824 18.5363C8.73805 18.5364 8.73787 18.5365 8.73767 18.5365C8.73767 18.5366 8.73768 18.5365 8.73767 18.5365L7.3739 16.5267C10.5202 15.1267 12.7216 13.069 13.7984 10.8079H8.36688V8.63046L16.9291 8.63047C16.6076 10.614 15.8557 12.3764 14.6848 13.9237C15.874 14.7334 17.1438 15.6717 18.2251 16.6103L16.6578 18.68C15.5557 17.6134 14.371 16.6055 13.1394 15.6214C12.395 16.3092 11.547 16.9436 10.5969 17.5256ZM31.8955 12.1251V14.533H39.9379L41.3298 12.1251H31.8955ZM53.7827 6.56189L53.3408 8.28962H54.8604L55.3012 6.56189H53.7827ZM51.3513 6.56189L50.9106 8.28962H52.4302L52.871 6.56189H51.3513ZM45.9291 18.9428L44.4946 16.9455C45.9176 16.5384 47.1377 15.9168 48.1075 15.1511C47.3533 14.4926 46.5161 13.8469 45.7377 13.2968C45.3318 13.667 44.9005 14.0141 44.4104 14.337L42.8305 12.7583C44.8763 11.2625 45.9776 9.51546 46.6234 7.63808L48.9448 8.21119C48.849 8.48682 48.7406 8.77393 48.6219 9.06111H53.4553C53.1748 13.532 50.8371 17.2615 45.9291 18.9428ZM50.6549 11.1668H47.5205C47.4018 11.3467 47.2061 11.6216 47.0746 11.8014C47.8634 12.2673 48.7623 12.9547 49.588 13.6132C50.0908 12.8832 50.5119 11.9683 50.6549 11.1668ZM22.8732 14.9699V13.8051C25.3258 13.5538 27.7066 13.1231 29.3577 12.6924L28.8911 10.3953C27.0367 10.9576 24.7994 11.3405 22.8971 11.5798C22.9091 10.6346 22.921 8.98122 22.945 8.03607L20.5402 8.63047V15.7356C20.5402 18.272 21.7246 18.5113 24.7755 18.5113C26.0436 18.5113 28.257 18.4874 29.3457 18.4275V16.1424C28.3527 16.2022 25.936 16.286 24.6797 16.286C23.1842 16.286 22.8732 16.2022 22.8732 14.9699ZM30.7542 8.25709C30.7542 9.19336 29.9953 9.95229 29.059 9.95229C28.1228 9.95229 27.3638 9.19336 27.3638 8.25709C27.3638 7.32087 28.1228 6.56189 29.059 6.56189C29.9953 6.56189 30.7542 7.32087 30.7542 8.25709ZM29.9006 8.25709C29.9006 7.79235 29.5238 7.41554 29.059 7.41554C28.5943 7.41554 28.2175 7.79235 28.2175 8.25709C28.2175 8.7219 28.5943 9.09863 29.059 9.09863C29.5238 9.09863 29.9006 8.7219 29.9006 8.25709Z\" fill=\"white\"/>\n</g>\n<defs>\n<clipPath id=\"clip0_10_438\">\n<rect width=\"72.4909\" height=\"26\" fill=\"white\" transform=\"translate(0.812012)\"/>\n</clipPath>\n</defs>\n</svg>\n", Ur = "<svg viewBox=\"0 0 74 26\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n<path d=\"M72.1973 0H1.9354C1.25055 0 0.697144 0.556428 0.697144 1.23822V24.7618C0.697144 25.4466 1.25055 26 1.9354 26H57.8275C58.491 26 59.1055 25.6454 59.4357 25.0706L73.0533 1.48589C73.4355 0.82548 72.9585 0 72.1973 0Z\" fill=\"#F72A48\"/>\n<path d=\"M13.1507 10.0632C12.9506 9.80871 12.6891 9.60628 12.3665 9.45625C12.0436 9.30623 11.7323 9.23123 11.4323 9.23123C11.2776 9.23123 11.1207 9.24486 10.9618 9.27214C10.8026 9.29942 10.6594 9.35184 10.5322 9.42899C10.4047 9.50633 10.298 9.60628 10.2117 9.72902C10.1252 9.85175 10.0821 10.0086 10.0821 10.1995C10.0821 10.3632 10.1162 10.4996 10.1844 10.6087C10.2526 10.7178 10.3525 10.8132 10.4844 10.8951C10.6161 10.9769 10.773 11.0519 10.9549 11.1201C11.1367 11.1883 11.3413 11.2588 11.5687 11.3315C11.896 11.4406 12.2369 11.5612 12.5915 11.6929C12.9461 11.8248 13.2687 11.9998 13.5598 12.218C13.8507 12.4362 14.0917 12.7068 14.2826 13.0294C14.4736 13.3523 14.569 13.7546 14.569 14.2364C14.569 14.7911 14.4667 15.2708 14.2622 15.6752C14.0576 16.0799 13.7825 16.414 13.4371 16.6776C13.0914 16.9414 12.6959 17.1368 12.2506 17.2641C11.805 17.3913 11.3457 17.455 10.8731 17.455C10.1821 17.455 9.51379 17.3344 8.86833 17.0936C8.22263 16.8528 7.68629 16.5095 7.25903 16.0639L8.7865 14.5092C9.02284 14.8003 9.33414 15.0434 9.72071 15.2388C10.107 15.4344 10.4913 15.532 10.8731 15.532C11.0457 15.532 11.2141 15.5139 11.3777 15.4775C11.5414 15.4412 11.6846 15.382 11.8073 15.3002C11.9301 15.2183 12.0277 15.1092 12.1006 14.9729C12.1732 14.8365 12.2097 14.6728 12.2097 14.4819C12.2097 14.3001 12.164 14.1456 12.0733 14.0182C11.9823 13.891 11.8527 13.7751 11.6846 13.6704C11.5163 13.566 11.3072 13.4705 11.0572 13.384C10.8071 13.2977 10.523 13.2046 10.2048 13.1044C9.89565 13.0045 9.59327 12.8862 9.29794 12.7499C9.00237 12.6135 8.73875 12.4385 8.5069 12.2248C8.27505 12.0113 8.08859 11.7521 7.94777 11.4474C7.80671 11.1429 7.73636 10.7723 7.73636 10.3359C7.73636 9.79955 7.84547 9.34034 8.06367 8.95847C8.28189 8.57661 8.5683 8.26292 8.92289 8.01745C9.27748 7.77196 9.67746 7.59253 10.123 7.47874C10.5684 7.36517 11.0185 7.30826 11.4732 7.30826C12.0187 7.30826 12.5755 7.40842 13.1439 7.6083C13.712 7.8084 14.2098 8.10396 14.6372 8.49477L13.1507 10.0632ZM22.97 12.4304C22.8217 11.9978 22.6086 11.6177 22.3304 11.2902C22.0524 10.9627 21.7125 10.7032 21.314 10.5147C20.9123 10.3232 20.4674 10.2274 19.9761 10.2274C19.4786 10.2274 19.043 10.3293 18.6753 10.5332C18.3076 10.7372 18.0171 10.9782 17.8101 11.2501H17.7668V10.4189H15.6411V20.5717L17.8781 20.0186V16.4594H17.9059C18.1129 16.7499 18.4034 16.9785 18.7772 17.1484C19.1511 17.3153 19.5466 17.4018 19.9637 17.4018C20.4736 17.4018 20.9277 17.2998 21.3263 17.099C21.7279 16.9013 22.0648 16.6355 22.3428 16.3018C22.6209 15.9713 22.831 15.5881 22.9793 15.1494C23.1245 14.7137 23.1956 14.2595 23.1956 13.7868C23.1956 13.314 23.1214 12.8598 22.97 12.4304ZM20.9247 14.4356C20.8566 14.6488 20.7578 14.8373 20.6249 15.001C20.492 15.1648 20.3283 15.2946 20.1275 15.3965C19.9267 15.4954 19.6949 15.5448 19.4323 15.5448C19.1758 15.5448 18.9503 15.4954 18.7494 15.3965C18.5486 15.2946 18.3787 15.1648 18.2397 15.001C18.0975 14.8373 17.9894 14.6488 17.9121 14.4418C17.8349 14.2317 17.7947 14.0185 17.7947 13.7991C17.7947 13.5829 17.8349 13.3697 17.9121 13.1595C17.9894 12.9495 18.0975 12.764 18.2397 12.6003C18.3787 12.4365 18.5486 12.3037 18.7494 12.2048C18.9503 12.1029 19.1758 12.0534 19.4323 12.0534C19.6949 12.0534 19.9267 12.1029 20.1275 12.2048C20.3283 12.3037 20.492 12.4335 20.6249 12.5941C20.7578 12.7517 20.8566 12.9371 20.9247 13.1441C20.9926 13.3542 21.0266 13.5674 21.0266 13.7868C21.0266 14.003 20.9926 14.2193 20.9247 14.4356ZM31.1612 13.8954V14.1682C31.1612 14.2592 31.1565 14.3455 31.1476 14.4273H26.2242C26.2424 14.6183 26.2992 14.7911 26.3947 14.9456C26.4902 15.1003 26.6129 15.2343 26.7629 15.3479C26.913 15.4617 27.0811 15.5503 27.2676 15.6138C27.4538 15.6776 27.6471 15.7093 27.8472 15.7093C28.2017 15.7093 28.5018 15.6435 28.7473 15.5115C28.9928 15.3799 29.1926 15.2094 29.3473 15.0001L30.9021 15.9821C30.5837 16.4458 30.1633 16.8027 29.6406 17.0527C29.1176 17.3026 28.5108 17.4277 27.8199 17.4277C27.3106 17.4277 26.8288 17.348 26.3743 17.189C25.9195 17.0301 25.5219 16.7982 25.1809 16.4935C24.84 16.189 24.5717 15.8139 24.3763 15.3684C24.1807 14.923 24.0831 14.4137 24.0831 13.8409C24.0831 13.2864 24.1785 12.7839 24.3695 12.3339C24.5604 11.8838 24.8195 11.502 25.1468 11.1883C25.4742 10.8746 25.8605 10.6315 26.3061 10.4587C26.7514 10.2861 27.2335 10.1995 27.7517 10.1995C28.2516 10.1995 28.7108 10.2837 29.1291 10.4518C29.5472 10.6202 29.9065 10.8633 30.2065 11.1815C30.5066 11.4998 30.7406 11.8862 30.9089 12.3407C31.0771 12.7954 31.1612 13.3137 31.1612 13.8954ZM29.1019 13.0362C29.1019 12.6817 28.9904 12.3771 28.7677 12.1225C28.5448 11.8681 28.2107 11.7406 27.7654 11.7406C27.5471 11.7406 27.347 11.7747 27.1653 11.8429C26.9833 11.9111 26.8243 12.0044 26.6879 12.1225C26.5515 12.2408 26.4424 12.3795 26.3606 12.5385C26.2788 12.6976 26.2332 12.8636 26.2242 13.0362H29.1019ZM39.153 13.8954V14.1682C39.153 14.2592 39.1483 14.3455 39.1394 14.4273H34.2161C34.2342 14.6183 34.2911 14.7911 34.3865 14.9456C34.482 15.1003 34.6047 15.2343 34.7548 15.3479C34.9048 15.4617 35.0729 15.5503 35.2594 15.6138C35.4456 15.6776 35.6389 15.7093 35.839 15.7093C36.1936 15.7093 36.4936 15.6435 36.7391 15.5115C36.9846 15.3799 37.1845 15.2094 37.3392 15.0001L38.8939 15.9821C38.5755 16.4458 38.1551 16.8027 37.6324 17.0527C37.1094 17.3026 36.5025 17.4277 35.8117 17.4277C35.3024 17.4277 34.8206 17.348 34.3661 17.189C33.9113 17.0301 33.5137 16.7982 33.1728 16.4935C32.8318 16.189 32.5635 15.8139 32.3681 15.3684C32.1725 14.923 32.0749 14.4137 32.0749 13.8409C32.0749 13.2864 32.1703 12.7839 32.3613 12.3339C32.5522 11.8838 32.8113 11.502 33.1387 11.1883C33.4659 10.8746 33.8523 10.6315 34.2979 10.4587C34.7432 10.2861 35.2253 10.1995 35.7435 10.1995C36.2434 10.1995 36.7027 10.2837 37.121 10.4518C37.5391 10.6202 37.8983 10.8633 38.1984 11.1815C38.4984 11.4998 38.7324 11.8862 38.9007 12.3407C39.0688 12.7954 39.153 13.3137 39.153 13.8954ZM37.0937 13.0362C37.0937 12.6817 36.9823 12.3771 36.7596 12.1225C36.5366 11.8681 36.2025 11.7406 35.7571 11.7406C35.5389 11.7406 35.3388 11.7747 35.1571 11.8429C34.9751 11.9111 34.8161 12.0044 34.6798 12.1225C34.5434 12.2408 34.4343 12.3795 34.3524 12.5385C34.2706 12.6976 34.225 12.8636 34.2161 13.0362H37.0937ZM45.3733 7.11546V11.1419H45.3454C45.1539 10.9133 44.8851 10.7032 44.5391 10.5147C44.193 10.3232 43.7728 10.2274 43.2722 10.2274C42.7809 10.2274 42.336 10.3232 41.9406 10.5147C41.545 10.7032 41.2114 10.9627 40.9333 11.2902C40.6552 11.6177 40.442 11.9978 40.2906 12.4304C40.1423 12.8598 40.0682 13.314 40.0682 13.7868C40.0682 14.2595 40.1392 14.7137 40.2845 15.1494C40.4297 15.5881 40.6428 15.9713 40.9179 16.3018C41.1959 16.6355 41.5358 16.9013 41.9344 17.099C42.336 17.2998 42.7903 17.4018 43.3001 17.4018C43.7542 17.4018 44.1837 17.306 44.5885 17.1206C44.9932 16.9352 45.3022 16.6695 45.5216 16.3235H45.5494V17.2103H47.6072V6.56238L45.3733 7.11546ZM45.3516 14.4418C45.2744 14.6488 45.1663 14.8373 45.0242 15.001C44.882 15.1648 44.712 15.2946 44.5112 15.3965C44.3135 15.4954 44.0849 15.5448 43.8315 15.5448C43.5657 15.5448 43.334 15.4954 43.1363 15.3965C42.9354 15.2946 42.7655 15.1648 42.6296 15.001C42.4936 14.8373 42.3917 14.6488 42.3237 14.4356C42.2557 14.2193 42.2217 14.003 42.2217 13.7868C42.2217 13.5674 42.2557 13.3542 42.3237 13.1441C42.3917 12.9371 42.4936 12.7517 42.6296 12.5941C42.7655 12.4335 42.9354 12.3037 43.1363 12.2048C43.334 12.1029 43.5657 12.0534 43.8315 12.0534C44.0849 12.0534 44.3135 12.1029 44.5112 12.2048C44.712 12.3037 44.882 12.4365 45.0242 12.6003C45.1663 12.764 45.2744 12.9495 45.3516 13.1595C45.4289 13.3697 45.466 13.5829 45.466 13.7991C45.466 14.0185 45.4289 14.2317 45.3516 14.4418ZM49.0353 11.3451C49.4352 10.9633 49.9013 10.6769 50.4331 10.4859C50.965 10.295 51.5082 10.1995 52.0629 10.1995C52.6357 10.1995 53.1199 10.2701 53.5153 10.4109C53.9108 10.552 54.2313 10.7702 54.4768 11.0655C54.7223 11.3611 54.9017 11.7338 55.0155 12.1839C55.1291 12.6339 55.186 13.1681 55.186 13.7863V17.2095H53.1403V16.4867H53.0994C52.9266 16.7686 52.6651 16.9868 52.3152 17.1413C51.9651 17.2958 51.5856 17.3731 51.1764 17.3731C50.9037 17.3731 50.6217 17.3367 50.3309 17.2641C50.0398 17.1914 49.7738 17.0731 49.533 16.9095C49.292 16.7458 49.0943 16.5276 48.9398 16.2548C48.7851 15.9821 48.7079 15.6458 48.7079 15.2456C48.7079 14.7546 48.842 14.3591 49.1102 14.0591C49.3783 13.7591 49.724 13.5272 50.1467 13.3636C50.5695 13.1999 51.04 13.0908 51.5583 13.0362C52.0765 12.9817 52.5811 12.9544 53.0721 12.9544V12.8453C53.0721 12.5091 52.9538 12.2612 52.7175 12.102C52.481 11.9431 52.1901 11.8634 51.8447 11.8634C51.5263 11.8634 51.2195 11.9316 50.9241 12.0679C50.6286 12.2043 50.3763 12.368 50.1672 12.5589L49.0353 11.3451ZM53.1403 14.25H52.8539C52.6084 14.25 52.3606 14.2615 52.1106 14.2841C51.8604 14.3069 51.6378 14.3502 51.4423 14.4137C51.2467 14.4774 51.0854 14.5705 50.9582 14.6933C50.8308 14.816 50.7673 14.9775 50.7673 15.1774C50.7673 15.3049 50.7967 15.414 50.8559 15.5047C50.9149 15.5957 50.99 15.6684 51.081 15.7229C51.1717 15.7775 51.2764 15.8163 51.3946 15.8389C51.5127 15.8617 51.6265 15.873 51.7356 15.873C52.1901 15.873 52.5379 15.7481 52.7789 15.4979C53.0197 15.248 53.1403 14.9093 53.1403 14.4819V14.25Z\" fill=\"white\"/>\n</svg>\n", Wr = "<svg viewBox=\"0 0 134 20\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n<g clip-path=\"url(#clip0_10_447)\">\n<path d=\"M1.04199 0V3.126H2.08399V10.418H19.168V0H1.04199ZM4.74999 2.292H9.47999V4.272H4.74999V2.292ZM4.74999 6.146H9.47999V8.126H4.74999V6.146ZM16.5 8.124H11.77V6.144H16.5V8.124ZM16.5 4.27H11.77V2.29H16.5V4.27Z\" fill=\"#191919\"/>\n<path d=\"M15.088 11.876L16.892 15H19.538L17.734 11.876H15.088Z\" fill=\"#191919\"/>\n<path d=\"M15.404 15L13.6 11.876H10.954L12.758 15H15.404Z\" fill=\"#191919\"/>\n<path d=\"M2.76 20L4.77 12.5H2.01L0 20H2.76Z\" fill=\"#191919\"/>\n<path d=\"M17.708 16.584V17.416H8.49998V14.374H9.41598V12.5H5.83398V18.124L7.70798 20H18.958L20.834 18.124V16.584H17.708Z\" fill=\"#191919\"/>\n<path d=\"M68.86 7.99L68.51 8.342L62.266 14.584H65.802L70.276 10.108L74.752 14.584H78.288L71.36 7.658V6.042H75.944V3.75H71.36V1.874H72.278V0H68.86V3.75H64.278V6.042H68.86V7.99Z\" fill=\"#191919\"/>\n<path d=\"M62.17 3.124L59.046 0H55.804L58.93 3.124H62.17Z\" fill=\"#191919\"/>\n<path d=\"M75.152 17.416H62.482L60.986 14.824V5H56.194V7.5H58.278V15.6L53.876 20H57.412L59.742 17.67L61.088 20H61.946H76.402L78.278 18.126V16.584H75.152V17.416Z\" fill=\"#191919\"/>\n<path d=\"M28.53 14.584L30.186 8.40601H27.426L25.77 14.584H28.53Z\" fill=\"#191919\"/>\n<path d=\"M40.352 0.00201416H32.91L30.788 2.29401H38.228L40.352 0.00201416Z\" fill=\"#191919\"/>\n<path d=\"M45.142 17.418H36.186V12.722L46.196 2.71H48.268V0H45.166L36.186 8.98V5.874H37.102V4H33.478V11.688L29.056 16.11V16.114H29.052L25.166 20H28.908L33.478 15.43V18.126L35.352 20H46.392L48.268 18.126V16.584H45.142V17.418Z\" fill=\"#191919\"/>\n<path d=\"M47.434 14.584L45.76 8.33398H43L44.674 14.584H47.434Z\" fill=\"#191919\"/>\n<path d=\"M91.754 7.952C91.568 7.716 91.326 7.528 91.026 7.388C90.726 7.248 90.438 7.18 90.16 7.18C90.016 7.18 89.87 7.192 89.724 7.218C89.576 7.244 89.444 7.292 89.326 7.364C89.208 7.436 89.108 7.528 89.028 7.642C88.948 7.756 88.908 7.902 88.908 8.078C88.908 8.23 88.94 8.356 89.002 8.458C89.066 8.56 89.158 8.648 89.28 8.724C89.402 8.8 89.548 8.87 89.716 8.932C89.884 8.996 90.074 9.06 90.286 9.128C90.59 9.23 90.906 9.342 91.236 9.464C91.566 9.586 91.864 9.748 92.134 9.952C92.404 10.154 92.628 10.406 92.804 10.706C92.982 11.006 93.07 11.378 93.07 11.826C93.07 12.34 92.976 12.786 92.786 13.162C92.596 13.538 92.34 13.848 92.02 14.092C91.7 14.336 91.332 14.518 90.918 14.636C90.504 14.754 90.078 14.814 89.64 14.814C88.998 14.814 88.378 14.702 87.78 14.478C87.18 14.254 86.684 13.936 86.286 13.522L87.704 12.08C87.924 12.35 88.212 12.576 88.57 12.758C88.928 12.94 89.286 13.03 89.64 13.03C89.8 13.03 89.956 13.014 90.108 12.98C90.26 12.946 90.392 12.892 90.506 12.816C90.62 12.74 90.71 12.638 90.778 12.512C90.846 12.386 90.88 12.234 90.88 12.056C90.88 11.878 90.838 11.744 90.754 11.626C90.67 11.508 90.55 11.4 90.394 11.304C90.238 11.208 90.044 11.118 89.812 11.038C89.58 10.958 89.316 10.872 89.022 10.778C88.736 10.686 88.454 10.576 88.18 10.448C87.906 10.322 87.662 10.16 87.446 9.96C87.23 9.762 87.058 9.522 86.928 9.238C86.798 8.956 86.732 8.612 86.732 8.206C86.732 7.708 86.834 7.282 87.036 6.928C87.238 6.574 87.504 6.282 87.834 6.054C88.164 5.826 88.534 5.66 88.948 5.554C89.362 5.448 89.778 5.396 90.2 5.396C90.706 5.396 91.222 5.488 91.75 5.674C92.278 5.86 92.74 6.134 93.136 6.496L91.756 7.952H91.754Z\" fill=\"#191919\"/>\n<path d=\"M101.434 10.148C101.296 9.746 101.098 9.394 100.84 9.09C100.582 8.786 100.266 8.546 99.896 8.37C99.524 8.192 99.11 8.104 98.654 8.104C98.198 8.104 97.788 8.198 97.446 8.388C97.104 8.578 96.836 8.8 96.644 9.054H96.604V8.282H94.632V17.704L96.708 17.19V13.888H96.734C96.926 14.158 97.196 14.37 97.542 14.528C97.888 14.682 98.256 14.764 98.644 14.764C99.118 14.764 99.538 14.67 99.908 14.484C100.28 14.3 100.594 14.054 100.852 13.744C101.11 13.438 101.306 13.082 101.442 12.674C101.576 12.27 101.642 11.848 101.642 11.41C101.642 10.972 101.574 10.55 101.432 10.152L101.434 10.148ZM99.536 12.008C99.472 12.206 99.382 12.38 99.258 12.532C99.134 12.684 98.982 12.804 98.796 12.9C98.61 12.992 98.394 13.038 98.15 13.038C97.906 13.038 97.702 12.992 97.516 12.9C97.33 12.806 97.172 12.684 97.042 12.532C96.91 12.38 96.81 12.206 96.738 12.014C96.666 11.82 96.63 11.622 96.63 11.418C96.63 11.214 96.668 11.02 96.738 10.824C96.81 10.63 96.91 10.456 97.042 10.306C97.172 10.154 97.328 10.03 97.516 9.938C97.702 9.844 97.912 9.798 98.15 9.798C98.388 9.798 98.608 9.844 98.796 9.938C98.982 10.03 99.134 10.15 99.258 10.3C99.382 10.446 99.474 10.618 99.536 10.81C99.6 11.004 99.63 11.202 99.63 11.406C99.63 11.61 99.598 11.808 99.536 12.008Z\" fill=\"#191919\"/>\n<path d=\"M109.6 11.508V11.762C109.6 11.846 109.596 11.926 109.588 12.002H105.02C105.036 12.18 105.09 12.34 105.178 12.482C105.266 12.626 105.38 12.75 105.52 12.856C105.66 12.962 105.816 13.044 105.988 13.102C106.16 13.162 106.34 13.19 106.526 13.19C106.856 13.19 107.134 13.128 107.362 13.006C107.59 12.884 107.776 12.726 107.918 12.532L109.36 13.444C109.064 13.874 108.674 14.206 108.19 14.438C107.704 14.67 107.142 14.786 106.5 14.786C106.028 14.786 105.58 14.712 105.158 14.564C104.736 14.416 104.368 14.202 104.05 13.918C103.734 13.636 103.484 13.288 103.304 12.874C103.122 12.46 103.032 11.988 103.032 11.456C103.032 10.924 103.12 10.476 103.298 10.058C103.476 9.63999 103.716 9.28599 104.02 8.99399C104.324 8.70199 104.682 8.47799 105.096 8.31599C105.51 8.15599 105.956 8.07599 106.438 8.07599C106.92 8.07599 107.328 8.15399 107.716 8.30999C108.104 8.46599 108.438 8.69199 108.716 8.98799C108.994 9.28399 109.212 9.64199 109.368 10.064C109.524 10.486 109.602 10.966 109.602 11.506L109.6 11.508ZM107.69 10.71C107.69 10.38 107.586 10.098 107.38 9.86199C107.174 9.62599 106.864 9.50799 106.45 9.50799C106.248 9.50799 106.062 9.53999 105.894 9.60199C105.726 9.66599 105.578 9.75199 105.452 9.86199C105.326 9.97199 105.224 10.1 105.148 10.248C105.072 10.396 105.03 10.55 105.022 10.71H107.692H107.69Z\" fill=\"#191919\"/>\n<path d=\"M117.584 11.508V11.762C117.584 11.846 117.58 11.926 117.572 12.002H113.004C113.02 12.18 113.074 12.34 113.162 12.482C113.25 12.626 113.364 12.75 113.504 12.856C113.644 12.962 113.8 13.044 113.972 13.102C114.144 13.162 114.324 13.19 114.51 13.19C114.84 13.19 115.118 13.128 115.346 13.006C115.574 12.884 115.76 12.726 115.902 12.532L117.344 13.444C117.048 13.874 116.658 14.206 116.174 14.438C115.688 14.67 115.126 14.786 114.484 14.786C114.012 14.786 113.564 14.712 113.142 14.564C112.72 14.416 112.352 14.202 112.034 13.918C111.718 13.636 111.468 13.288 111.288 12.874C111.106 12.46 111.016 11.988 111.016 11.456C111.016 10.924 111.104 10.476 111.282 10.058C111.46 9.63999 111.7 9.28599 112.004 8.99399C112.308 8.70199 112.666 8.47799 113.08 8.31599C113.494 8.15599 113.94 8.07599 114.422 8.07599C114.904 8.07599 115.312 8.15399 115.7 8.30999C116.088 8.46599 116.422 8.69199 116.7 8.98799C116.978 9.28399 117.196 9.64199 117.352 10.064C117.508 10.486 117.586 10.966 117.586 11.506L117.584 11.508ZM115.672 10.71C115.672 10.38 115.568 10.098 115.362 9.86199C115.156 9.62599 114.846 9.50799 114.432 9.50799C114.23 9.50799 114.044 9.53999 113.876 9.60199C113.708 9.66599 113.56 9.75199 113.434 9.86199C113.308 9.97199 113.206 10.1 113.13 10.248C113.054 10.396 113.012 10.55 113.004 10.71H115.674H115.672Z\" fill=\"#191919\"/>\n<path d=\"M123.924 5.216V8.952H123.898C123.72 8.74 123.47 8.544 123.15 8.37C122.828 8.192 122.438 8.104 121.974 8.104C121.51 8.104 121.106 8.192 120.738 8.37C120.37 8.544 120.062 8.786 119.804 9.09C119.546 9.394 119.348 9.746 119.208 10.148C119.07 10.546 119.002 10.968 119.002 11.406C119.002 11.844 119.068 12.266 119.202 12.67C119.336 13.078 119.534 13.432 119.79 13.74C120.048 14.05 120.364 14.296 120.734 14.48C121.106 14.666 121.528 14.76 122.002 14.76C122.424 14.76 122.822 14.672 123.198 14.5C123.574 14.328 123.86 14.082 124.064 13.76H124.09V14.582H126V4.702L123.928 5.216H123.924ZM123.902 12.014C123.83 12.206 123.73 12.382 123.598 12.532C123.466 12.684 123.308 12.804 123.122 12.9C122.938 12.992 122.726 13.038 122.492 13.038C122.246 13.038 122.03 12.992 121.846 12.9C121.66 12.806 121.502 12.684 121.376 12.532C121.25 12.38 121.156 12.206 121.092 12.008C121.028 11.808 120.998 11.606 120.998 11.406C120.998 11.206 121.03 11.004 121.092 10.81C121.156 10.618 121.25 10.446 121.376 10.3C121.502 10.15 121.66 10.03 121.846 9.938C122.03 9.844 122.244 9.798 122.492 9.798C122.74 9.798 122.94 9.844 123.122 9.938C123.308 10.03 123.466 10.154 123.598 10.306C123.73 10.458 123.83 10.63 123.902 10.824C123.974 11.018 124.008 11.216 124.008 11.418C124.008 11.62 123.974 11.82 123.902 12.014Z\" fill=\"#191919\"/>\n<path d=\"M127.888 9.13999C128.26 8.78599 128.692 8.51999 129.186 8.34199C129.68 8.16399 130.184 8.07599 130.698 8.07599C131.212 8.07599 131.678 8.14199 132.046 8.27199C132.412 8.40199 132.71 8.60599 132.938 8.87999C133.166 9.15399 133.332 9.49999 133.438 9.91799C133.544 10.336 133.596 10.832 133.596 11.406V14.582H131.698V13.912H131.66C131.5 14.174 131.256 14.376 130.932 14.52C130.608 14.664 130.254 14.736 129.876 14.736C129.622 14.736 129.362 14.702 129.092 14.634C128.822 14.566 128.576 14.456 128.352 14.304C128.128 14.152 127.944 13.95 127.802 13.696C127.658 13.442 127.586 13.13 127.586 12.76C127.586 12.304 127.71 11.938 127.96 11.658C128.208 11.38 128.53 11.164 128.922 11.012C129.314 10.86 129.75 10.758 130.232 10.708C130.712 10.658 131.182 10.632 131.636 10.632V10.53C131.636 10.218 131.526 9.98799 131.306 9.83999C131.086 9.69199 130.816 9.61799 130.496 9.61799C130.2 9.61799 129.916 9.68199 129.642 9.80799C129.368 9.93399 129.134 10.086 128.94 10.264L127.89 9.13799L127.888 9.13999ZM131.698 11.836H131.432C131.204 11.836 130.974 11.846 130.742 11.868C130.51 11.89 130.304 11.93 130.122 11.988C129.94 12.048 129.79 12.134 129.672 12.248C129.554 12.362 129.494 12.512 129.494 12.698C129.494 12.816 129.522 12.918 129.576 13.002C129.63 13.086 129.7 13.154 129.784 13.204C129.868 13.254 129.966 13.29 130.076 13.312C130.186 13.334 130.292 13.344 130.392 13.344C130.814 13.344 131.136 13.228 131.36 12.996C131.584 12.764 131.696 12.45 131.696 12.054V11.838L131.698 11.836Z\" fill=\"#191919\"/>\n</g>\n<defs>\n<clipPath id=\"clip0_10_447\">\n<rect width=\"133.596\" height=\"20\" fill=\"white\"/>\n</clipPath>\n</defs>\n</svg>\n", Gr = "<svg viewBox=\"0 0 118 19\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">\n<g clip-path=\"url(#clip0_2813_53)\">\n<path d=\"M10.2549 0.167748H9.8355C8.91288 0.167748 8.57739 0.475856 8.57739 1.39676V13.4386C8.57739 15.1435 7.54351 16.2613 5.75649 16.2613C3.96946 16.2613 2.90649 15.1435 2.90649 13.4386V1.39676C2.90649 0.474144 2.59838 0.167748 1.67748 0.167748H1.25811C0.335496 0.167748 0 0.474144 0 1.39676V13.4386C0 15.1144 0.530631 16.4564 1.5936 17.4629C2.65487 18.4694 4.05162 18.9726 5.75649 18.9726C7.46135 18.9726 8.82901 18.4694 9.89198 17.4629C10.9532 16.429 11.4856 15.0887 11.4856 13.4386V1.39676C11.4856 0.474144 11.1775 0.167748 10.2566 0.167748H10.2549ZM27.4644 16.15H20.787L27.437 5.05811C27.9403 4.24847 28.1919 3.43712 28.1919 2.60009V1.53883C28.1919 0.504955 27.8838 0.169459 26.8499 0.169459H19.6128C18.6902 0.169459 18.3838 0.477568 18.3838 1.39847V1.6227C18.3838 2.54532 18.6919 2.85171 19.6128 2.85171H25.4241L18.8014 13.9436C18.2708 14.7259 18.0192 15.5646 18.0192 16.4581V17.4646C18.0192 18.4985 18.3547 18.834 19.3886 18.834H27.4627C28.3853 18.834 28.6917 18.5259 28.6917 17.605V17.3807C28.6917 16.4581 28.3836 16.1517 27.4627 16.1517L27.4644 16.15ZM43.195 1.50973C42.9434 0.475856 42.5532 0.167748 41.5193 0.167748H39.4806C38.4468 0.167748 38.0565 0.475856 37.8049 1.50973L34.1726 17.6032C33.9484 18.4968 34.2565 18.8323 35.1791 18.8323H35.6532C36.6306 18.8323 36.9661 18.5806 37.1904 17.6032L37.8049 14.7532H43.1968L43.8404 17.6032C44.0355 18.5806 44.371 18.8323 45.3484 18.8323H45.8516C46.7742 18.8323 47.0532 18.4968 46.829 17.6032L43.1968 1.50973H43.195ZM38.3886 12.0984L38.9192 9.64036C39.5611 6.65 40.0643 3.85649 40.4563 1.31459C40.7079 2.90649 41.2386 5.67261 42.0773 9.66946L42.6079 12.1001H38.3886V12.0984ZM61.8869 9.24838C63.4514 8.82901 64.5127 7.6 64.5127 5.39189V4.77739C64.5127 1.98387 62.5562 0.167748 59.0078 0.167748H54.6498C53.6159 0.167748 53.2805 0.503243 53.2805 1.53712V17.4629C53.2805 18.4968 53.6159 18.8323 54.6498 18.8323H59.2595C62.9191 18.8323 65.016 16.8758 65.016 13.8871V13.2726C65.016 10.842 63.8143 9.50171 61.8869 9.25009V9.24838ZM56.1596 2.79351H58.9257C60.6853 2.79351 61.6644 3.60315 61.6644 5.02901V5.58703C61.6644 7.17892 60.9096 8.10153 58.6741 8.10153H56.1596V2.79351ZM62.1386 13.7194C62.1386 15.2565 61.1047 16.2065 58.9805 16.2065H56.1578V10.6742H59.0078C61.103 10.6742 62.1369 11.513 62.1369 13.1887V13.7194H62.1386ZM79.9078 1.50973C79.6562 0.475856 79.266 0.167748 78.2321 0.167748H76.1934C75.1596 0.167748 74.7693 0.475856 74.5177 1.50973L70.8854 17.6032C70.6612 18.4968 70.9693 18.8323 71.8919 18.8323H72.366C73.3434 18.8323 73.6789 18.5806 73.9032 17.6032L74.5177 14.7532H79.9096L80.5532 17.6032C80.7483 18.5806 81.0838 18.8323 82.0612 18.8323H82.5644C83.487 18.8323 83.766 18.4968 83.5418 17.6032L79.9096 1.50973H79.9078ZM75.1014 12.0984L75.632 9.64036C76.2739 6.65 76.7771 3.85649 77.1691 1.31459C77.4207 2.90649 77.9514 5.67261 78.7901 9.66946L79.3207 12.1001H75.1014V12.0984ZM95.2191 7.99027C93.5707 7.23541 92.2578 6.25802 92.2578 4.91604C92.2578 3.49189 93.2078 2.65315 94.7997 2.65315C96.4755 2.65315 97.5094 3.60315 97.5933 5.08378C97.6771 5.86604 98.0126 6.09027 98.9061 6.09027H99.3255C100.192 6.09027 100.5 5.78216 100.5 5.02901C100.5 3.54838 99.9691 2.34676 98.9352 1.42414C97.9014 0.474144 96.532 0 94.8271 0C93.2352 0 91.8932 0.474144 90.8594 1.39676C89.8255 2.31937 89.2949 3.51928 89.2949 5.00162C89.2384 8.43874 92.3691 9.83549 94.7433 10.8129C96.419 11.5113 97.7336 12.5177 97.7336 13.8854C97.7336 15.4225 96.6433 16.316 94.9401 16.316C93.0401 16.316 91.9224 15.1983 91.8385 13.7177C91.7546 12.9354 91.4465 12.6838 90.553 12.6838H90.1062C89.2966 12.6838 88.9046 13.0193 88.9046 13.6903C88.9046 15.2548 89.4626 16.5403 90.6095 17.5177C91.7546 18.495 93.1805 18.9709 94.9401 18.9709C96.6997 18.9709 98.0691 18.4968 99.103 17.5468C100.137 16.5968 100.667 15.3386 100.667 13.8032C100.695 10.45 97.6224 8.99847 95.2191 7.99198V7.99027ZM115.811 2.85C116.734 2.85 117.04 2.54189 117.04 1.62099V1.39676C117.04 0.474144 116.732 0.167748 115.811 0.167748H108.909C107.876 0.167748 107.54 0.503243 107.54 1.53712V17.4629C107.54 18.4968 107.876 18.8323 108.909 18.8323H115.811C116.734 18.8323 117.04 18.5241 117.04 17.6032V17.379C117.04 16.4564 116.732 16.15 115.811 16.15H110.419V10.842H115.226C116.148 10.842 116.427 10.563 116.427 9.58387V9.35964C116.427 8.43703 116.148 8.13063 115.226 8.13063H110.419V2.85H115.811Z\" fill=\"black\"/>\n</g>\n<defs>\n<clipPath id=\"clip0_2813_53\">\n<rect width=\"117.081\" height=\"19\" fill=\"white\"/>\n</clipPath>\n</defs>\n</svg>\n", Kr = class extends A {
 	constructor(...e) {
 		super(...e), this.language = "", this.brand = "", this.label = "";
 	}
 	static {
-		this.styles = P();
+		this.styles = M();
 	}
 	updated() {
 		this.setAttribute("role", "img"), this.setAttribute("aria-label", this.label || (this.brand === "uzabase" ? "Uzabase" : "Speeda"));
 	}
 	#e() {
-		if (this.brand === "uzabase") return Br;
-		if (this.brand === "speeda") return this.language === "en" ? Rr : this.language === "zh" ? zr : Lr;
+		if (this.brand === "uzabase") return Gr;
+		if (this.brand === "speeda") return this.language === "en" ? Ur : this.language === "zh" ? Wr : Hr;
 	}
 	render() {
 		let e = this.#e();
-		return e ? O`${He(e)}` : A;
+		return e ? D`${We(e)}` : k;
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0
-})], Vr.prototype, "language", void 0), I([N({
+})], Kr.prototype, "language", void 0), P([j({
 	type: String,
 	reflect: !0
-})], Vr.prototype, "brand", void 0), I([N({ type: String })], Vr.prototype, "label", void 0);
-var Hr = class extends Vr {};
-customElements.get("mi-logo") || customElements.define("mi-logo", Vr), customElements.get("sp-logo") || customElements.define("sp-logo", Hr);
+})], Kr.prototype, "brand", void 0), P([j({ type: String })], Kr.prototype, "label", void 0);
+var qr = class extends Kr {};
+customElements.get("mi-logo") || customElements.define("mi-logo", Kr), customElements.get("sp-logo") || customElements.define("sp-logo", qr);
 //#endregion
 //#region src/components/logo/speeda-logos.ts
-var Ur = {
+var Jr = {
 	"inverse:false|logoLanguage:en|symbol:false|subBrand:null": "<svg width=\"71\" height=\"27\" viewBox=\"0 0 71 27\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M0.00185488 19.2035L2.01304 17.336C2.75205 18.3829 4.08635 19.1219 5.48185 19.1219C6.77535 19.1219 8.23205 18.4441 8.23205 16.8437C8.23205 15.2432 6.87735 14.8112 5.2148 14.2576L4.59912 14.0731C2.40248 13.3545 0.637942 12.328 0.637942 9.63901C0.637942 6.37512 3.57359 5 6.24126 5C8.13005 5 9.93632 5.71862 11.0648 6.8888L9.15558 8.7776C8.51949 7.89487 7.39011 7.34038 6.15874 7.34038C4.92736 7.34038 3.46974 7.97644 3.46974 9.49526C3.46974 10.8908 4.59819 11.3424 6.09661 11.8356L6.7123 12.0201C9.23718 12.8203 11.0842 13.806 11.0842 16.5766C11.0842 19.9221 8.33404 21.503 5.4392 21.503C3.36589 21.503 1.27218 20.6824 0 19.2044L0.00185488 19.2035Z\" fill=\"#F72A48\"/><path d=\"M12.6829 26.27V10.672H15.2161V12.1676H15.2764C15.9746 11.13 17.3107 10.392 18.8666 10.392C21.9785 10.392 23.9934 12.8649 23.9934 15.8571C23.9934 18.8493 22.0183 21.3825 18.8472 21.3825C17.4507 21.3825 16.0942 20.7845 15.3561 19.707H15.2958V26.2691H12.6829V26.27ZM21.3999 15.858C21.3999 14.1222 20.3224 12.5274 18.288 12.5274C16.4132 12.5274 15.1567 14.1232 15.1567 15.8784C15.1567 17.6337 16.4132 19.2091 18.288 19.2091C20.3224 19.2091 21.3999 17.6133 21.3999 15.858Z\" fill=\"#F72A48\"/><path d=\"M25.1477 15.8978C25.1477 12.6071 27.5409 10.3529 30.6333 10.3529C33.7256 10.3529 35.76 12.5273 35.76 15.8385C35.76 16.0981 35.76 16.3568 35.7396 16.596H27.7412C27.8015 18.1519 29.1571 19.349 30.7733 19.349C32.0501 19.349 32.9875 18.7111 33.5263 17.9331L35.3613 19.2099C34.2838 20.6861 32.7084 21.4242 30.7334 21.4242C27.6021 21.4242 25.1486 19.2702 25.1486 15.8987L25.1477 15.8978ZM33.2657 14.8603C33.2258 13.4045 32.3487 12.2667 30.6527 12.2667C28.9568 12.2667 27.8404 13.4638 27.7208 14.8603H33.2657Z\" fill=\"#F72A48\"/><path d=\"M36.9358 15.8978C36.9358 12.6071 39.329 10.3529 42.4214 10.3529C45.5137 10.3529 47.5481 12.5273 47.5481 15.8385C47.5481 16.0981 47.5481 16.3568 47.5286 16.596H39.5302C39.5905 18.1519 40.9461 19.349 42.5623 19.349C43.8391 19.349 44.7765 18.7111 45.3153 17.9331L47.1503 19.2099C46.0728 20.6861 44.4974 21.4242 42.5224 21.4242C39.3911 21.4242 36.9376 19.2702 36.9376 15.8987L36.9358 15.8978ZM45.0538 14.8603C45.0139 13.4045 44.1358 12.2667 42.4408 12.2667C40.7458 12.2667 39.6285 13.4638 39.5089 14.8603H45.0538Z\" fill=\"#F72A48\"/><path d=\"M48.719 15.858C48.719 12.8658 50.7339 10.3928 53.8652 10.3928C55.4007 10.3928 56.658 11.1309 57.3562 12.0683H57.4165V5.50623H60.01V21.1043H57.5565V19.5688H57.5167C56.7591 20.7455 55.3024 21.3843 53.8865 21.3843C50.6755 21.3843 48.7199 18.8511 48.7199 15.8589L48.719 15.858ZM57.5556 15.8774C57.5556 14.1222 56.2992 12.5264 54.4039 12.5264C52.389 12.5264 51.332 14.1222 51.332 15.8571C51.332 17.5919 52.389 19.2081 54.4039 19.2081C56.2992 19.2081 57.5556 17.6522 57.5556 15.8774Z\" fill=\"#F72A48\"/><path d=\"M61.2786 18.1316C61.2786 15.0995 64.829 14.6007 68.1402 14.6007H68.2802V14.3614C68.2802 13.0253 67.3631 12.3864 66.0066 12.3864C64.8892 12.3864 63.8526 12.8648 63.1942 13.5232L61.8377 12.0072C62.9151 10.9696 64.5304 10.3521 66.2458 10.3521C69.4568 10.3521 70.754 12.2872 70.754 14.7203V19.2285C70.754 19.8665 70.7939 20.6249 70.8737 21.1034H68.5203C68.4406 20.6843 68.3608 20.1854 68.3608 19.7673H68.321C67.6033 20.8048 66.4461 21.363 65.0098 21.363C63.3741 21.363 61.2795 20.5452 61.2795 18.1316H61.2786ZM68.3395 16.7751V16.2762H67.8805C65.9852 16.2762 63.7515 16.496 63.7515 18.0519C63.7515 19.1488 64.7492 19.4881 65.6663 19.4881C67.3622 19.4881 68.3395 18.3514 68.3395 16.7751Z\" fill=\"#F72A48\"/></svg>",
 	"inverse:false|logoLanguage:en|symbol:true|subBrand:ai-agent": "<svg width=\"192\" height=\"26\" viewBox=\"0 0 192 26\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M121.313 5.56238L127.755 20.7723H126.045L124.394 16.8155H116.601L114.951 20.7723H113.261L119.862 5.56238H121.314H121.313ZM117.157 15.4642H123.857L120.537 7.25289L117.157 15.4642Z\" fill=\"url(#paint0_linear_1_709)\"/><path d=\"M128.987 20.7732V5.56323H130.518V20.7732H128.987Z\" fill=\"url(#paint1_linear_1_709)\"/><path d=\"M143.8 5.56238L150.242 20.7723H148.532L146.881 16.8155H139.088L137.437 20.7723H135.747L142.348 5.56238H143.8ZM139.644 15.4642H146.345L143.024 7.25289L139.644 15.4642Z\" fill=\"url(#paint2_linear_1_709)\"/><path d=\"M150.996 24.1533L151.93 23.0396C152.885 24.1136 154.316 24.7291 155.768 24.7291C158.73 24.7291 159.645 22.6809 159.645 20.3351V18.7444H159.586C158.85 20.1558 157.28 20.9313 155.689 20.9313C152.667 20.9313 150.639 18.6446 150.639 15.7017C150.639 12.7588 152.648 10.413 155.669 10.413C157.279 10.413 158.83 11.1884 159.645 12.719H159.685V10.6912H161.096V20.2344C161.096 23.2762 159.765 26 155.748 26C153.958 26 152.169 25.3244 150.996 24.1505V24.1533ZM159.744 15.6832C159.744 13.476 158.154 11.6275 155.887 11.6275C153.621 11.6275 152.129 13.4964 152.129 15.6832C152.129 17.8701 153.54 19.7195 155.887 19.7195C158.234 19.7195 159.744 17.9107 159.744 15.6832Z\" fill=\"url(#paint3_linear_1_709)\"/><path d=\"M163.163 15.7026C163.163 12.6007 165.35 10.4138 168.213 10.4138C171.255 10.4138 173.005 12.5813 173.005 15.5038C173.005 15.6831 173.005 15.8819 172.986 16.0806H164.655C164.695 18.0493 166.126 19.8387 168.353 19.8387C169.785 19.8387 170.878 19.1631 171.574 18.1889L172.588 19.0244C171.534 20.396 170.142 21.0523 168.353 21.0523C165.331 21.0523 163.163 18.8848 163.163 15.7035V15.7026ZM171.534 14.9872C171.475 13.0184 170.301 11.5877 168.214 11.5877C166.127 11.5877 164.734 13.4371 164.655 14.9872H171.534Z\" fill=\"url(#paint4_linear_1_709)\"/><path d=\"M175.073 20.7732V12.9991C175.073 12.4223 175.053 11.3289 174.993 10.693H176.385C176.425 11.23 176.484 12.1839 176.484 12.7015H176.524C177.061 11.3492 178.512 10.4148 180.063 10.4148C182.727 10.4148 183.761 12.3835 183.761 14.5704V20.7741H182.31V15.0279C182.31 13.378 181.793 11.6478 179.705 11.6478C177.916 11.6478 176.544 13.1386 176.544 15.5445V20.7741H175.073V20.7732Z\" fill=\"url(#paint5_linear_1_709)\"/><path d=\"M186.823 18.1085V11.9048H184.795V10.6921H186.823V7.78894H188.255V10.6921H191.039V11.9048H188.255V17.969C188.255 19.2417 188.811 19.7584 189.825 19.7584C190.203 19.7584 190.64 19.6789 190.978 19.5199L191.039 20.7131C190.621 20.8721 190.044 20.9719 189.508 20.9719C187.719 20.9719 186.824 19.9377 186.824 18.1085H186.823Z\" fill=\"url(#paint6_linear_1_709)\"/><path d=\"M36.9232 18.8794L38.9279 17.0179C39.6646 18.0614 40.9946 18.798 42.3857 18.798C43.675 18.798 45.1271 18.1224 45.1271 16.5271C45.1271 14.9318 43.7767 14.5011 42.1195 13.9493L41.5057 13.7653C39.3161 13.049 37.5572 12.0258 37.5572 9.34634C37.5572 6.09288 40.4835 4.72217 43.1426 4.72217C45.0254 4.72217 46.8259 5.43848 47.9508 6.60493L46.0477 8.48768C45.4136 7.60777 44.2878 7.05505 43.0604 7.05505C41.8329 7.05505 40.38 7.68911 40.38 9.20308C40.38 10.5941 41.5048 11.0442 42.9985 11.536L43.6122 11.7199C46.129 12.5175 47.9702 13.5001 47.9702 16.2618C47.9702 19.5966 45.2287 21.1725 42.3441 21.1725C40.2774 21.1725 38.1904 20.3545 36.9222 18.8812L36.9232 18.8794Z\" fill=\"#F72A48\"/><path d=\"M49.5636 25.9223V10.3741H52.0887V11.865H52.1488C52.8448 10.8307 54.1767 10.095 55.7276 10.095C58.8295 10.095 60.837 12.56 60.837 15.5427C60.837 18.5253 58.8683 21.0505 55.7073 21.0505C54.3153 21.0505 52.9631 20.4543 52.2283 19.3803H52.1682V25.9214H49.5636V25.9223ZM58.2528 15.5436C58.2528 13.8134 57.1787 12.2236 55.1509 12.2236C53.282 12.2236 52.0296 13.8143 52.0296 15.5639C52.0296 17.3136 53.282 18.8839 55.1509 18.8839C57.1787 18.8839 58.2528 17.2933 58.2528 15.5436Z\" fill=\"#F72A48\"/><path d=\"M61.9878 15.5833C61.9878 12.3031 64.3734 10.0562 67.4558 10.0562C70.5383 10.0562 72.5653 12.2236 72.5653 15.5242C72.5653 15.783 72.5653 16.0409 72.5449 16.2793H64.5721C64.6322 17.8303 65.9835 19.0235 67.5945 19.0235C68.8672 19.0235 69.8017 18.3876 70.3387 17.6121L72.1678 18.8849C71.0938 20.3563 69.5234 21.0921 67.5547 21.0921C64.4334 21.0921 61.9878 18.945 61.9878 15.5843V15.5833ZM70.0799 14.55C70.0401 13.0989 69.1658 11.9648 67.4752 11.9648C65.7847 11.9648 64.6719 13.158 64.5527 14.55H70.0799Z\" fill=\"#F72A48\"/><path d=\"M73.7382 15.5833C73.7382 12.3031 76.1237 10.0562 79.2062 10.0562C82.2887 10.0562 84.3156 12.2236 84.3156 15.5242C84.3156 15.783 84.3156 16.0409 84.2962 16.2793H76.3234C76.3834 17.8303 77.7347 19.0235 79.3458 19.0235C80.6185 19.0235 81.5529 18.3876 82.09 17.6121L83.9191 18.8849C82.8451 20.3563 81.2747 21.0921 79.306 21.0921C76.1847 21.0921 73.7391 18.945 73.7391 15.5843L73.7382 15.5833ZM81.8311 14.55C81.7914 13.0989 80.9161 11.9648 79.2265 11.9648C77.5369 11.9648 76.4232 13.158 76.304 14.55H81.8311Z\" fill=\"#F72A48\"/><path d=\"M85.4849 15.5436C85.4849 12.561 87.4933 10.0959 90.6146 10.0959C92.1452 10.0959 93.3986 10.8317 94.0936 11.7661H94.1537V5.22498H96.7389V20.7732H94.2933V19.2426H94.2535C93.4984 20.4155 92.0463 21.0523 90.6349 21.0523C87.4342 21.0523 85.4849 18.5272 85.4849 15.5446V15.5436ZM94.2923 15.564C94.2923 13.8143 93.0399 12.2236 91.1507 12.2236C89.1422 12.2236 88.0886 13.8143 88.0886 15.5436C88.0886 17.273 89.1422 18.884 91.1507 18.884C93.0399 18.884 94.2923 17.333 94.2923 15.564Z\" fill=\"#F72A48\"/><path d=\"M98.0033 17.8109C98.0033 14.7885 101.542 14.2912 104.843 14.2912H104.983V14.0527C104.983 12.7209 104.068 12.084 102.716 12.084C101.602 12.084 100.569 12.561 99.9129 13.2172L98.5606 11.706C99.6346 10.6717 101.245 10.0562 102.955 10.0562C106.155 10.0562 107.449 11.9851 107.449 14.4104V18.9043C107.449 19.5402 107.488 20.2963 107.568 20.7732H105.222C105.142 20.3554 105.063 19.8581 105.063 19.4413H105.023C104.308 20.4756 103.154 21.032 101.723 21.032C100.092 21.032 98.0042 20.2168 98.0042 17.8109H98.0033ZM105.042 16.4586V15.9614H104.584C102.695 15.9614 100.468 16.1804 100.468 17.7314C100.468 18.8248 101.463 19.1631 102.377 19.1631C104.067 19.1631 105.042 18.0299 105.042 16.4586Z\" fill=\"#F72A48\"/><path d=\"M27.6767 6.10949C27.6767 2.73679 23.5313 0.00277284 18.506 0H11.353L16.4051 2.01955C15.4438 2.22289 14.5112 2.6379 13.6794 3.27472L5.22498 10.3686H8.25754L22.7909 24.902C23.4444 25.5554 24.3298 25.9214 25.2532 25.9214H27.514L21.5681 19.9755V16.3921C21.5681 14.0102 23.9611 11.474 26.5537 11.474C28.43 11.474 29.3727 13.1155 28.2553 14.8116C30.0548 13.9668 31.2231 12.9066 31.64 11.3474C32.2445 9.08937 30.212 6.59844 27.6776 6.10857L27.6767 6.10949Z\" fill=\"#F72A48\"/><path d=\"M2.68318 13.7025L6.41634 15.1952L16.1241 24.9029C16.7775 25.5564 17.663 25.9224 18.5863 25.9224H20.8471L8.6263 13.7015H2.68225L2.68318 13.7025Z\" fill=\"#F72A48\"/><path d=\"M0 17.7758L3.88475 19.3295L9.45816 24.9029C10.1116 25.5563 10.9971 25.9224 11.9204 25.9224H14.1812L6.03462 17.7758H0Z\" fill=\"#F72A48\"/><defs><linearGradient id=\"paint0_linear_1_709\" x1=\"130.95\" y1=\"-5.52621\" x2=\"174.114\" y2=\"37.6377\" gradientUnits=\"userSpaceOnUse\"><stop offset=\"0.4\" stop-color=\"#F72A48\"/><stop offset=\"0.46\" stop-color=\"#F42A4B\"/><stop offset=\"0.51\" stop-color=\"#ED2A55\"/><stop offset=\"0.55\" stop-color=\"#E02A66\"/><stop offset=\"0.59\" stop-color=\"#CE2A7D\"/><stop offset=\"0.63\" stop-color=\"#B72B9C\"/><stop offset=\"0.67\" stop-color=\"#9B2CC1\"/><stop offset=\"0.7\" stop-color=\"#7C2DEB\"/><stop offset=\"1\" stop-color=\"#2A2AF7\"/></linearGradient><linearGradient id=\"paint1_linear_1_709\" x1=\"130.95\" y1=\"-5.52628\" x2=\"174.114\" y2=\"37.6374\" gradientUnits=\"userSpaceOnUse\"><stop offset=\"0.4\" stop-color=\"#F72A48\"/><stop offset=\"0.46\" stop-color=\"#F42A4B\"/><stop offset=\"0.51\" stop-color=\"#ED2A55\"/><stop offset=\"0.55\" stop-color=\"#E02A66\"/><stop offset=\"0.59\" stop-color=\"#CE2A7D\"/><stop offset=\"0.63\" stop-color=\"#B72B9C\"/><stop offset=\"0.67\" stop-color=\"#9B2CC1\"/><stop offset=\"0.7\" stop-color=\"#7C2DEB\"/><stop offset=\"1\" stop-color=\"#2A2AF7\"/></linearGradient><linearGradient id=\"paint2_linear_1_709\" x1=\"130.95\" y1=\"-5.52621\" x2=\"174.114\" y2=\"37.6377\" gradientUnits=\"userSpaceOnUse\"><stop offset=\"0.4\" stop-color=\"#F72A48\"/><stop offset=\"0.46\" stop-color=\"#F42A4B\"/><stop offset=\"0.51\" stop-color=\"#ED2A55\"/><stop offset=\"0.55\" stop-color=\"#E02A66\"/><stop offset=\"0.59\" stop-color=\"#CE2A7D\"/><stop offset=\"0.63\" stop-color=\"#B72B9C\"/><stop offset=\"0.67\" stop-color=\"#9B2CC1\"/><stop offset=\"0.7\" stop-color=\"#7C2DEB\"/><stop offset=\"1\" stop-color=\"#2A2AF7\"/></linearGradient><linearGradient id=\"paint3_linear_1_709\" x1=\"130.95\" y1=\"-5.52625\" x2=\"174.114\" y2=\"37.6376\" gradientUnits=\"userSpaceOnUse\"><stop offset=\"0.4\" stop-color=\"#F72A48\"/><stop offset=\"0.46\" stop-color=\"#F42A4B\"/><stop offset=\"0.51\" stop-color=\"#ED2A55\"/><stop offset=\"0.55\" stop-color=\"#E02A66\"/><stop offset=\"0.59\" stop-color=\"#CE2A7D\"/><stop offset=\"0.63\" stop-color=\"#B72B9C\"/><stop offset=\"0.67\" stop-color=\"#9B2CC1\"/><stop offset=\"0.7\" stop-color=\"#7C2DEB\"/><stop offset=\"1\" stop-color=\"#2A2AF7\"/></linearGradient><linearGradient id=\"paint4_linear_1_709\" x1=\"130.95\" y1=\"-5.52632\" x2=\"174.114\" y2=\"37.6375\" gradientUnits=\"userSpaceOnUse\"><stop offset=\"0.4\" stop-color=\"#F72A48\"/><stop offset=\"0.46\" stop-color=\"#F42A4B\"/><stop offset=\"0.51\" stop-color=\"#ED2A55\"/><stop offset=\"0.55\" stop-color=\"#E02A66\"/><stop offset=\"0.59\" stop-color=\"#CE2A7D\"/><stop offset=\"0.63\" stop-color=\"#B72B9C\"/><stop offset=\"0.67\" stop-color=\"#9B2CC1\"/><stop offset=\"0.7\" stop-color=\"#7C2DEB\"/><stop offset=\"1\" stop-color=\"#2A2AF7\"/></linearGradient><linearGradient id=\"paint5_linear_1_709\" x1=\"130.95\" y1=\"-5.52626\" x2=\"174.114\" y2=\"37.6376\" gradientUnits=\"userSpaceOnUse\"><stop offset=\"0.4\" stop-color=\"#F72A48\"/><stop offset=\"0.46\" stop-color=\"#F42A4B\"/><stop offset=\"0.51\" stop-color=\"#ED2A55\"/><stop offset=\"0.55\" stop-color=\"#E02A66\"/><stop offset=\"0.59\" stop-color=\"#CE2A7D\"/><stop offset=\"0.63\" stop-color=\"#B72B9C\"/><stop offset=\"0.67\" stop-color=\"#9B2CC1\"/><stop offset=\"0.7\" stop-color=\"#7C2DEB\"/><stop offset=\"1\" stop-color=\"#2A2AF7\"/></linearGradient><linearGradient id=\"paint6_linear_1_709\" x1=\"130.95\" y1=\"-5.52624\" x2=\"174.114\" y2=\"37.6375\" gradientUnits=\"userSpaceOnUse\"><stop offset=\"0.4\" stop-color=\"#F72A48\"/><stop offset=\"0.46\" stop-color=\"#F42A4B\"/><stop offset=\"0.51\" stop-color=\"#ED2A55\"/><stop offset=\"0.55\" stop-color=\"#E02A66\"/><stop offset=\"0.59\" stop-color=\"#CE2A7D\"/><stop offset=\"0.63\" stop-color=\"#B72B9C\"/><stop offset=\"0.67\" stop-color=\"#9B2CC1\"/><stop offset=\"0.7\" stop-color=\"#7C2DEB\"/><stop offset=\"1\" stop-color=\"#2A2AF7\"/></linearGradient></defs></svg>",
 	"inverse:false|logoLanguage:en|symbol:true|subBrand:expert-research": "<svg width=\"256\" height=\"26\" viewBox=\"0 0 256 26\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M115.396 20.8343V5.57981H124.827V6.93607H116.91V12.2805H124.388V13.5969H116.91V19.4595H125.166V20.8352H115.395L115.396 20.8343Z\" fill=\"#F72A48\"/><path d=\"M125.565 20.8343L129.593 15.5297L125.964 10.7239H127.778L130.51 14.5526L133.262 10.7239H134.996L131.407 15.5093L135.455 20.8334H133.641L130.47 16.5059L127.34 20.8334H125.565V20.8343Z\" fill=\"#F72A48\"/><path d=\"M136.693 25.9988V10.7239H138.148V12.718H138.207C138.945 11.3219 140.421 10.4449 142.176 10.4449C145.187 10.4449 147.221 12.7579 147.221 15.7893C147.221 18.8207 145.187 21.1133 142.156 21.1133C140.541 21.1133 138.985 20.3355 138.227 18.8801H138.167V25.9988H136.691H136.693ZM145.706 15.7893C145.706 13.6154 144.331 11.6612 141.917 11.6612C139.664 11.6612 138.089 13.5755 138.089 15.7893C138.089 18.0031 139.664 19.897 141.917 19.897C144.331 19.897 145.706 17.9428 145.706 15.7893Z\" fill=\"#F72A48\"/><path d=\"M148.577 15.7494C148.577 12.6383 150.771 10.4449 153.643 10.4449C156.694 10.4449 158.448 12.6188 158.448 15.5501C158.448 15.73 158.448 15.9293 158.429 16.1286H150.074C150.113 18.1023 151.549 19.897 153.783 19.897C155.219 19.897 156.315 19.2194 157.013 18.2423L158.03 19.0794C156.974 20.4551 155.577 21.1133 153.783 21.1133C150.751 21.1133 148.578 18.9394 148.578 15.7494H148.577ZM156.973 15.0319C156.913 13.0582 155.736 11.6222 153.643 11.6222C151.549 11.6222 150.153 13.4763 150.074 15.0319H156.973Z\" fill=\"#F72A48\"/><path d=\"M160.522 20.8343V13.0369C160.522 12.4584 160.502 11.3617 160.443 10.7239H161.839C161.879 11.2625 161.939 12.2397 161.939 12.7783H161.979C162.537 11.2829 163.813 10.4449 165.209 10.4449C165.429 10.4449 165.668 10.4644 165.868 10.5052L165.807 11.8614C165.608 11.8012 165.349 11.7817 165.13 11.7817C162.976 11.7817 161.999 13.696 161.999 15.5501V20.8343H160.523H160.522Z\" fill=\"#F72A48\"/><path d=\"M168.439 18.1625V11.9411H166.405V10.7248H168.439V7.81295H169.875V10.7248H172.667V11.9411H169.875V18.0234C169.875 19.3 170.433 19.8182 171.45 19.8182C171.829 19.8182 172.268 19.7384 172.607 19.579L172.668 20.7758C172.249 20.9353 171.671 21.0354 171.132 21.0354C169.338 21.0354 168.44 19.998 168.44 18.1643L168.439 18.1625Z\" fill=\"#F72A48\"/><path d=\"M188.759 20.8343H186.905L182.757 13.7155H180.025V20.8343H178.49V5.57981H183.137C185.829 5.57981 188.322 6.55691 188.322 9.64768C188.322 12.0802 186.507 13.3364 184.373 13.596L188.76 20.8343H188.759ZM180.025 12.439H182.936C185.209 12.439 186.765 11.5815 186.765 9.64768C186.765 7.51362 184.97 6.89621 182.936 6.89621H180.025V12.4399V12.439Z\" fill=\"#F72A48\"/><path d=\"M189.478 15.7494C189.478 12.6383 191.671 10.4449 194.543 10.4449C197.594 10.4449 199.349 12.6188 199.349 15.5501C199.349 15.73 199.349 15.9293 199.329 16.1286H190.974C191.014 18.1023 192.45 19.897 194.683 19.897C196.119 19.897 197.216 19.2194 197.914 18.2423L198.931 19.0794C197.874 20.4551 196.478 21.1133 194.683 21.1133C191.652 21.1133 189.479 18.9394 189.479 15.7494H189.478ZM197.872 15.0319C197.812 13.0582 196.635 11.6222 194.542 11.6222C192.449 11.6222 191.053 13.4763 190.973 15.0319H197.873H197.872Z\" fill=\"#F72A48\"/><path d=\"M200.246 19.3389L201.303 18.462C201.921 19.3389 202.958 19.9174 204.174 19.9174C205.271 19.9174 206.447 19.3788 206.447 18.1032C206.447 16.8276 205.29 16.5281 203.696 16.1295C202.161 15.7707 200.744 15.2117 200.744 13.378C200.744 11.3441 202.518 10.4467 204.294 10.4467C205.709 10.4467 207.066 11.0048 207.764 12.0422L206.726 12.8793C206.208 12.1015 205.351 11.6231 204.273 11.6231C203.296 11.6231 202.12 12.0422 202.12 13.2186C202.12 14.395 202.997 14.6741 204.573 15.0532C206.567 15.5121 207.903 16.2102 207.903 17.9845C207.903 20.1584 206.088 21.1152 204.134 21.1152C202.619 21.1152 201.163 20.5172 200.245 19.3408L200.246 19.3389Z\" fill=\"#F72A48\"/><path d=\"M209.02 15.7494C209.02 12.6383 211.213 10.4449 214.085 10.4449C217.136 10.4449 218.891 12.6188 218.891 15.5501C218.891 15.73 218.891 15.9293 218.871 16.1286H210.516C210.556 18.1023 211.992 19.897 214.225 19.897C215.661 19.897 216.758 19.2194 217.456 18.2423L218.473 19.0794C217.416 20.4551 216.02 21.1133 214.225 21.1133C211.194 21.1133 209.021 18.9394 209.021 15.7494H209.02ZM217.415 15.0319C217.355 13.0582 216.178 11.6222 214.085 11.6222C211.992 11.6222 210.596 13.4763 210.516 15.0319H217.416H217.415Z\" fill=\"#F72A48\"/><path d=\"M220.088 18.0624C220.088 15.1116 223.577 14.6722 226.489 14.6722H227.187V14.2133C227.187 12.4584 226.07 11.6407 224.436 11.6407C223.279 11.6407 222.202 12.1191 221.485 12.8375L220.707 11.8799C221.664 10.9825 223.08 10.4439 224.536 10.4439C227.228 10.4439 228.584 11.9791 228.584 14.3125V18.7196C228.584 19.4372 228.643 20.3151 228.764 20.8333H227.408C227.328 20.3346 227.248 19.5568 227.248 19.0385H227.188C226.51 20.3948 225.194 21.1123 223.638 21.1123C222.083 21.1123 220.089 20.2752 220.089 18.0614L220.088 18.0624ZM227.186 16.4475V15.7698H226.309C224.255 15.7698 221.564 16.0294 221.564 18.0429C221.564 19.4789 222.84 19.9369 223.937 19.9369C226.21 19.9369 227.187 18.2617 227.187 16.4475H227.186Z\" fill=\"#F72A48\"/><path d=\"M231.274 20.8343V13.0369C231.274 12.4584 231.254 11.3617 231.195 10.7239H232.591C232.631 11.2625 232.691 12.2397 232.691 12.7783H232.731C233.289 11.2829 234.565 10.4449 235.962 10.4449C236.181 10.4449 236.42 10.4644 236.62 10.5052L236.56 11.8614C236.36 11.8012 236.101 11.7817 235.882 11.7817C233.728 11.7817 232.751 13.696 232.751 15.5501V20.8343H231.275H231.274Z\" fill=\"#F72A48\"/><path d=\"M236.619 15.7893C236.619 12.6383 238.872 10.4449 241.903 10.4449C243.299 10.4449 244.715 11.003 245.532 12.0005L244.455 12.8775C243.916 12.1599 242.939 11.6806 241.922 11.6806C239.549 11.6806 238.154 13.595 238.154 15.7884C238.154 17.9818 239.55 19.8961 241.943 19.8961C243 19.8961 243.956 19.4771 244.595 18.7596L245.572 19.6569C244.695 20.6136 243.398 21.1124 241.943 21.1124C238.892 21.1124 236.619 18.9783 236.619 15.7884V15.7893Z\" fill=\"#F72A48\"/><path d=\"M246.909 20.8342V5.23948H248.364V12.679H248.404C248.923 11.3431 250.338 10.4458 251.894 10.4458C254.565 10.4458 255.603 12.4194 255.603 14.6137V20.8351H254.147V15.0921C254.147 13.4373 253.649 11.7019 251.555 11.7019C249.74 11.7019 248.364 13.1972 248.364 15.5899V20.8342H246.909Z\" fill=\"#F72A48\"/><path d=\"M37.0345 18.9349L39.0453 17.0679C39.7841 18.1145 41.1181 18.8534 42.5133 18.8534C43.8066 18.8534 45.263 18.1757 45.263 16.5756C45.263 14.9755 43.9085 14.5435 42.2464 13.9901L41.6308 13.8056C39.4346 13.0871 37.6705 12.0609 37.6705 9.37248C37.6705 6.10928 40.6055 4.73447 43.2726 4.73447C45.161 4.73447 46.9669 5.45293 48.0951 6.62286L46.1863 8.51125C45.5503 7.62871 44.4212 7.07433 43.1901 7.07433C41.959 7.07433 40.5017 7.71029 40.5017 9.22878C40.5017 10.624 41.6299 11.0755 43.128 11.5686L43.7435 11.7531C46.2679 12.5532 48.1145 13.5386 48.1145 16.3086C48.1145 19.6534 45.3649 21.234 42.4707 21.234C40.3978 21.234 38.3046 20.4136 37.0327 18.9359L37.0345 18.9349Z\" fill=\"#F72A48\"/><path d=\"M49.7128 26V10.4053H52.2455V11.9006H52.3057C53.0038 10.8632 54.3397 10.1253 55.8952 10.1253C59.0064 10.1253 61.0209 12.5977 61.0209 15.5893C61.0209 18.5809 59.0463 21.1136 55.8758 21.1136C54.4796 21.1136 53.1234 20.5156 52.3854 19.4384H52.3252V25.9991H49.7128V26ZM58.427 15.5902C58.427 13.8548 57.3498 12.2603 55.3158 12.2603C53.4414 12.2603 52.1852 13.8557 52.1852 15.6106C52.1852 17.3655 53.4414 18.9406 55.3158 18.9406C57.3498 18.9406 58.427 17.3451 58.427 15.5902Z\" fill=\"#F72A48\"/><path d=\"M62.174 15.6301C62.174 12.34 64.5667 10.0864 67.6584 10.0864C70.7501 10.0864 72.784 12.2603 72.784 15.5708C72.784 15.8303 72.784 16.089 72.7636 16.3282H64.767C64.8272 17.8837 66.1826 19.0806 67.7984 19.0806C69.0749 19.0806 70.0122 18.4428 70.5508 17.665L72.3854 18.9415C71.3082 20.4174 69.7331 21.1553 67.7585 21.1553C64.6279 21.1553 62.175 19.0018 62.175 15.631L62.174 15.6301ZM70.2903 14.5927C70.2504 13.1373 69.3734 11.9998 67.6779 11.9998C65.9823 11.9998 64.8662 13.1966 64.7466 14.5927H70.2903Z\" fill=\"#F72A48\"/><path d=\"M73.9596 15.6301C73.9596 12.34 76.3523 10.0864 79.444 10.0864C82.5357 10.0864 84.5696 12.2603 84.5696 15.5708C84.5696 15.8303 84.5696 16.089 84.5502 16.3282H76.5535C76.6137 17.8837 77.9691 19.0806 79.5849 19.0806C80.8615 19.0806 81.7987 18.4428 82.3373 17.665L84.1719 18.9415C83.0947 20.4174 81.5197 21.1553 79.5451 21.1553C76.4144 21.1553 73.9615 19.0018 73.9615 15.631L73.9596 15.6301ZM82.0768 14.5927C82.0369 13.1373 81.159 11.9998 79.4644 11.9998C77.7698 11.9998 76.6527 13.1966 76.5331 14.5927H82.0768Z\" fill=\"#F72A48\"/><path d=\"M85.7414 15.5902C85.7414 12.5986 87.7559 10.1262 90.8865 10.1262C92.4217 10.1262 93.6788 10.8641 94.3768 11.8014H94.4371V5.2407H97.03V20.8354H94.5771V19.3002H94.5372C93.7798 20.4767 92.3234 21.1154 90.9078 21.1154C87.6975 21.1154 85.7423 18.5827 85.7423 15.5911L85.7414 15.5902ZM94.5752 15.6097C94.5752 13.8548 93.3191 12.2593 91.4242 12.2593C89.4097 12.2593 88.3529 13.8548 88.3529 15.5893C88.3529 17.3238 89.4097 18.9396 91.4242 18.9396C93.3191 18.9396 94.5752 17.384 94.5752 15.6097Z\" fill=\"#F72A48\"/><path d=\"M98.2973 17.8633C98.2973 14.8319 101.847 14.3331 105.157 14.3331H105.297V14.0939C105.297 12.7581 104.381 12.1193 103.024 12.1193C101.907 12.1193 100.871 12.5977 100.213 13.2559L98.8563 11.7402C99.9335 10.7028 101.548 10.0854 103.263 10.0854C106.474 10.0854 107.771 12.0201 107.771 14.4527V18.96C107.771 19.5978 107.811 20.3561 107.89 20.8345H105.537C105.458 20.4155 105.378 19.9167 105.378 19.4986H105.338C104.621 20.536 103.464 21.0941 102.028 21.0941C100.392 21.0941 98.2982 20.2764 98.2982 17.8633H98.2973ZM105.358 16.507V16.0083H104.899C103.004 16.0083 100.771 16.228 100.771 17.7836C100.771 18.8803 101.768 19.2196 102.685 19.2196C104.381 19.2196 105.358 18.083 105.358 16.507Z\" fill=\"#F72A48\"/><path d=\"M27.7594 6.12776C27.7594 2.74498 23.6016 0.00278113 18.5613 0H11.3869L16.4541 2.02559C15.49 2.22954 14.5546 2.64578 13.7202 3.28452L5.24058 10.3996H8.28221L22.859 24.9764C23.5145 25.6318 24.4026 25.9989 25.3287 25.9989H27.5962L21.6326 20.0353V16.4411C21.6326 14.0521 24.0327 11.5083 26.633 11.5083C28.5149 11.5083 29.4615 13.1548 28.3397 14.8559C30.1447 14.0086 31.3165 12.9452 31.7346 11.3813C32.3409 9.11655 30.3023 6.61817 27.7603 6.12683L27.7594 6.12776Z\" fill=\"#F72A48\"/><path d=\"M2.69122 13.7425L6.43555 15.2397L16.1723 24.9764C16.8277 25.6318 17.7158 25.9999 18.6419 25.9999H20.9095L8.65212 13.7425H2.69029H2.69122Z\" fill=\"#F72A48\"/><path d=\"M0 17.828L3.89637 19.3864L9.48644 24.9765C10.1419 25.6319 11.03 25.9999 11.9561 25.9999H14.2236L6.05267 17.828H0Z\" fill=\"#F72A48\"/></svg>",
@@ -3589,12 +3714,12 @@ var Ur = {
 	"inverse:true|logoLanguage:en|symbol:true|subBrand:expert-research": "<svg width=\"256\" height=\"26\" viewBox=\"0 0 256 26\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M115.396 20.8343V5.57981H124.827V6.93607H116.91V12.2805H124.388V13.5969H116.91V19.4595H125.166V20.8352H115.395L115.396 20.8343Z\" fill=\"white\"/><path d=\"M125.565 20.8343L129.593 15.5297L125.964 10.7239H127.778L130.51 14.5526L133.262 10.7239H134.996L131.407 15.5093L135.455 20.8334H133.641L130.47 16.5059L127.34 20.8334H125.565V20.8343Z\" fill=\"white\"/><path d=\"M136.693 25.9988V10.7239H138.148V12.718H138.207C138.945 11.3219 140.421 10.4449 142.176 10.4449C145.187 10.4449 147.221 12.7579 147.221 15.7893C147.221 18.8207 145.187 21.1133 142.156 21.1133C140.541 21.1133 138.985 20.3355 138.227 18.8801H138.167V25.9988H136.691H136.693ZM145.706 15.7893C145.706 13.6154 144.331 11.6612 141.917 11.6612C139.664 11.6612 138.089 13.5755 138.089 15.7893C138.089 18.0031 139.664 19.897 141.917 19.897C144.331 19.897 145.706 17.9428 145.706 15.7893Z\" fill=\"white\"/><path d=\"M148.577 15.7494C148.577 12.6383 150.771 10.4449 153.643 10.4449C156.694 10.4449 158.448 12.6188 158.448 15.5501C158.448 15.73 158.448 15.9293 158.429 16.1286H150.074C150.113 18.1023 151.549 19.897 153.783 19.897C155.219 19.897 156.315 19.2194 157.013 18.2423L158.03 19.0794C156.974 20.4551 155.577 21.1133 153.783 21.1133C150.751 21.1133 148.578 18.9394 148.578 15.7494H148.577ZM156.973 15.0319C156.913 13.0582 155.736 11.6222 153.643 11.6222C151.549 11.6222 150.153 13.4763 150.074 15.0319H156.973Z\" fill=\"white\"/><path d=\"M160.522 20.8343V13.0369C160.522 12.4584 160.502 11.3617 160.443 10.7239H161.839C161.879 11.2625 161.939 12.2397 161.939 12.7783H161.979C162.537 11.2829 163.813 10.4449 165.209 10.4449C165.429 10.4449 165.668 10.4644 165.868 10.5052L165.807 11.8614C165.608 11.8012 165.349 11.7817 165.13 11.7817C162.976 11.7817 161.999 13.696 161.999 15.5501V20.8343H160.523H160.522Z\" fill=\"white\"/><path d=\"M168.439 18.1625V11.9411H166.405V10.7248H168.439V7.81295H169.875V10.7248H172.667V11.9411H169.875V18.0234C169.875 19.3 170.433 19.8182 171.45 19.8182C171.829 19.8182 172.268 19.7384 172.607 19.579L172.668 20.7758C172.249 20.9353 171.671 21.0354 171.132 21.0354C169.338 21.0354 168.44 19.998 168.44 18.1643L168.439 18.1625Z\" fill=\"white\"/><path d=\"M188.759 20.8343H186.905L182.757 13.7155H180.025V20.8343H178.49V5.57981H183.137C185.829 5.57981 188.322 6.55691 188.322 9.64768C188.322 12.0802 186.507 13.3364 184.373 13.596L188.76 20.8343H188.759ZM180.025 12.439H182.936C185.209 12.439 186.765 11.5815 186.765 9.64768C186.765 7.51362 184.97 6.89621 182.936 6.89621H180.025V12.4399V12.439Z\" fill=\"white\"/><path d=\"M189.478 15.7494C189.478 12.6383 191.671 10.4449 194.543 10.4449C197.594 10.4449 199.349 12.6188 199.349 15.5501C199.349 15.73 199.349 15.9293 199.329 16.1286H190.974C191.014 18.1023 192.45 19.897 194.683 19.897C196.119 19.897 197.216 19.2194 197.914 18.2423L198.931 19.0794C197.874 20.4551 196.478 21.1133 194.683 21.1133C191.652 21.1133 189.479 18.9394 189.479 15.7494H189.478ZM197.872 15.0319C197.812 13.0582 196.635 11.6222 194.542 11.6222C192.449 11.6222 191.053 13.4763 190.973 15.0319H197.873H197.872Z\" fill=\"white\"/><path d=\"M200.246 19.3389L201.303 18.462C201.921 19.3389 202.958 19.9174 204.174 19.9174C205.271 19.9174 206.447 19.3788 206.447 18.1032C206.447 16.8276 205.29 16.5281 203.696 16.1295C202.161 15.7707 200.744 15.2117 200.744 13.378C200.744 11.3441 202.518 10.4467 204.294 10.4467C205.709 10.4467 207.066 11.0048 207.764 12.0422L206.726 12.8793C206.208 12.1015 205.351 11.6231 204.273 11.6231C203.296 11.6231 202.12 12.0422 202.12 13.2186C202.12 14.395 202.997 14.6741 204.573 15.0532C206.567 15.5121 207.903 16.2102 207.903 17.9845C207.903 20.1584 206.088 21.1152 204.134 21.1152C202.619 21.1152 201.163 20.5172 200.245 19.3408L200.246 19.3389Z\" fill=\"white\"/><path d=\"M209.02 15.7494C209.02 12.6383 211.213 10.4449 214.085 10.4449C217.136 10.4449 218.891 12.6188 218.891 15.5501C218.891 15.73 218.891 15.9293 218.871 16.1286H210.516C210.556 18.1023 211.992 19.897 214.225 19.897C215.661 19.897 216.758 19.2194 217.456 18.2423L218.473 19.0794C217.416 20.4551 216.02 21.1133 214.225 21.1133C211.194 21.1133 209.021 18.9394 209.021 15.7494H209.02ZM217.415 15.0319C217.355 13.0582 216.178 11.6222 214.085 11.6222C211.992 11.6222 210.596 13.4763 210.516 15.0319H217.416H217.415Z\" fill=\"white\"/><path d=\"M220.088 18.0624C220.088 15.1116 223.577 14.6722 226.489 14.6722H227.187V14.2133C227.187 12.4584 226.07 11.6407 224.436 11.6407C223.279 11.6407 222.202 12.1191 221.485 12.8375L220.707 11.8799C221.664 10.9825 223.08 10.4439 224.536 10.4439C227.228 10.4439 228.584 11.9791 228.584 14.3125V18.7196C228.584 19.4372 228.643 20.3151 228.764 20.8333H227.408C227.328 20.3346 227.248 19.5568 227.248 19.0385H227.188C226.51 20.3948 225.194 21.1123 223.638 21.1123C222.083 21.1123 220.089 20.2752 220.089 18.0614L220.088 18.0624ZM227.186 16.4475V15.7698H226.309C224.255 15.7698 221.564 16.0294 221.564 18.0429C221.564 19.4789 222.84 19.9369 223.937 19.9369C226.21 19.9369 227.187 18.2617 227.187 16.4475H227.186Z\" fill=\"white\"/><path d=\"M231.274 20.8343V13.0369C231.274 12.4584 231.254 11.3617 231.195 10.7239H232.591C232.631 11.2625 232.691 12.2397 232.691 12.7783H232.731C233.289 11.2829 234.565 10.4449 235.962 10.4449C236.181 10.4449 236.42 10.4644 236.62 10.5052L236.56 11.8614C236.36 11.8012 236.101 11.7817 235.882 11.7817C233.728 11.7817 232.751 13.696 232.751 15.5501V20.8343H231.275H231.274Z\" fill=\"white\"/><path d=\"M236.619 15.7893C236.619 12.6383 238.872 10.4449 241.903 10.4449C243.299 10.4449 244.715 11.003 245.532 12.0005L244.455 12.8775C243.916 12.1599 242.939 11.6806 241.922 11.6806C239.549 11.6806 238.154 13.595 238.154 15.7884C238.154 17.9818 239.55 19.8961 241.943 19.8961C243 19.8961 243.956 19.4771 244.595 18.7596L245.572 19.6569C244.695 20.6136 243.398 21.1124 241.943 21.1124C238.892 21.1124 236.619 18.9783 236.619 15.7884V15.7893Z\" fill=\"white\"/><path d=\"M246.909 20.8342V5.23948H248.364V12.679H248.404C248.923 11.3431 250.338 10.4458 251.894 10.4458C254.565 10.4458 255.603 12.4194 255.603 14.6137V20.8351H254.147V15.0921C254.147 13.4373 253.649 11.7019 251.555 11.7019C249.74 11.7019 248.364 13.1972 248.364 15.5899V20.8342H246.909Z\" fill=\"white\"/><path d=\"M37.0345 18.9349L39.0453 17.0679C39.7841 18.1145 41.1181 18.8534 42.5133 18.8534C43.8066 18.8534 45.263 18.1757 45.263 16.5756C45.263 14.9755 43.9085 14.5435 42.2464 13.9901L41.6308 13.8056C39.4346 13.0871 37.6705 12.0609 37.6705 9.37248C37.6705 6.10928 40.6055 4.73447 43.2726 4.73447C45.161 4.73447 46.9669 5.45293 48.0951 6.62286L46.1863 8.51125C45.5503 7.62871 44.4212 7.07433 43.1901 7.07433C41.959 7.07433 40.5017 7.71029 40.5017 9.22878C40.5017 10.624 41.6299 11.0755 43.128 11.5686L43.7435 11.7531C46.2679 12.5532 48.1145 13.5386 48.1145 16.3086C48.1145 19.6534 45.3649 21.234 42.4707 21.234C40.3978 21.234 38.3046 20.4136 37.0327 18.9359L37.0345 18.9349Z\" fill=\"white\"/><path d=\"M49.7128 26V10.4053H52.2455V11.9006H52.3057C53.0038 10.8632 54.3397 10.1253 55.8952 10.1253C59.0064 10.1253 61.0209 12.5977 61.0209 15.5893C61.0209 18.5809 59.0463 21.1136 55.8758 21.1136C54.4796 21.1136 53.1234 20.5156 52.3854 19.4384H52.3252V25.9991H49.7128V26ZM58.427 15.5902C58.427 13.8548 57.3498 12.2603 55.3158 12.2603C53.4414 12.2603 52.1852 13.8557 52.1852 15.6106C52.1852 17.3655 53.4414 18.9406 55.3158 18.9406C57.3498 18.9406 58.427 17.3451 58.427 15.5902Z\" fill=\"white\"/><path d=\"M62.174 15.6301C62.174 12.34 64.5667 10.0864 67.6584 10.0864C70.7501 10.0864 72.784 12.2603 72.784 15.5708C72.784 15.8303 72.784 16.089 72.7636 16.3282H64.767C64.8272 17.8837 66.1826 19.0806 67.7984 19.0806C69.0749 19.0806 70.0122 18.4428 70.5508 17.665L72.3854 18.9415C71.3082 20.4174 69.7331 21.1553 67.7585 21.1553C64.6279 21.1553 62.175 19.0018 62.175 15.631L62.174 15.6301ZM70.2903 14.5927C70.2504 13.1373 69.3734 11.9998 67.6779 11.9998C65.9823 11.9998 64.8662 13.1966 64.7466 14.5927H70.2903Z\" fill=\"white\"/><path d=\"M73.9596 15.6301C73.9596 12.34 76.3523 10.0864 79.444 10.0864C82.5357 10.0864 84.5696 12.2603 84.5696 15.5708C84.5696 15.8303 84.5696 16.089 84.5502 16.3282H76.5535C76.6137 17.8837 77.9691 19.0806 79.5849 19.0806C80.8615 19.0806 81.7987 18.4428 82.3373 17.665L84.1719 18.9415C83.0947 20.4174 81.5197 21.1553 79.5451 21.1553C76.4144 21.1553 73.9615 19.0018 73.9615 15.631L73.9596 15.6301ZM82.0768 14.5927C82.0369 13.1373 81.159 11.9998 79.4644 11.9998C77.7698 11.9998 76.6527 13.1966 76.5331 14.5927H82.0768Z\" fill=\"white\"/><path d=\"M85.7414 15.5902C85.7414 12.5986 87.7559 10.1262 90.8865 10.1262C92.4217 10.1262 93.6788 10.8641 94.3768 11.8014H94.4371V5.2407H97.03V20.8354H94.5771V19.3002H94.5372C93.7798 20.4767 92.3234 21.1154 90.9078 21.1154C87.6975 21.1154 85.7423 18.5827 85.7423 15.5911L85.7414 15.5902ZM94.5752 15.6097C94.5752 13.8548 93.3191 12.2593 91.4242 12.2593C89.4097 12.2593 88.3529 13.8548 88.3529 15.5893C88.3529 17.3238 89.4097 18.9396 91.4242 18.9396C93.3191 18.9396 94.5752 17.384 94.5752 15.6097Z\" fill=\"white\"/><path d=\"M98.2973 17.8633C98.2973 14.8319 101.847 14.3331 105.157 14.3331H105.297V14.0939C105.297 12.7581 104.381 12.1193 103.024 12.1193C101.907 12.1193 100.871 12.5977 100.213 13.2559L98.8563 11.7402C99.9335 10.7028 101.548 10.0854 103.263 10.0854C106.474 10.0854 107.771 12.0201 107.771 14.4527V18.96C107.771 19.5978 107.811 20.3561 107.89 20.8345H105.537C105.458 20.4155 105.378 19.9167 105.378 19.4986H105.338C104.621 20.536 103.464 21.0941 102.028 21.0941C100.392 21.0941 98.2982 20.2764 98.2982 17.8633H98.2973ZM105.358 16.507V16.0083H104.899C103.004 16.0083 100.771 16.228 100.771 17.7836C100.771 18.8803 101.768 19.2196 102.685 19.2196C104.381 19.2196 105.358 18.083 105.358 16.507Z\" fill=\"white\"/><path d=\"M27.7594 6.12776C27.7594 2.74498 23.6016 0.00278113 18.5613 0H11.3869L16.4541 2.02559C15.49 2.22954 14.5546 2.64578 13.7202 3.28452L5.24058 10.3996H8.28221L22.859 24.9764C23.5145 25.6318 24.4026 25.9989 25.3287 25.9989H27.5962L21.6326 20.0353V16.4411C21.6326 14.0521 24.0327 11.5083 26.633 11.5083C28.5149 11.5083 29.4615 13.1548 28.3397 14.8559C30.1447 14.0086 31.3165 12.9452 31.7346 11.3813C32.3409 9.11655 30.3023 6.61817 27.7603 6.12683L27.7594 6.12776Z\" fill=\"white\"/><path d=\"M2.69122 13.7425L6.43555 15.2397L16.1723 24.9764C16.8277 25.6318 17.7158 25.9999 18.6419 25.9999H20.9095L8.65212 13.7425H2.69029H2.69122Z\" fill=\"white\"/><path d=\"M0 17.828L3.89637 19.3864L9.48644 24.9765C10.1419 25.6319 11.03 25.9999 11.9561 25.9999H14.2236L6.05267 17.828H0Z\" fill=\"white\"/></svg>",
 	"inverse:true|logoLanguage:en|symbol:true|subBrand:null": "<svg width=\"108\" height=\"26\" viewBox=\"0 0 108 26\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><path d=\"M37.0347 18.9349L39.0455 17.0678C39.7843 18.1145 41.1183 18.8533 42.5135 18.8533C43.8068 18.8533 45.2632 18.1756 45.2632 16.5756C45.2632 14.9755 43.9088 14.5435 42.2466 13.99L41.631 13.8055C39.4348 13.0871 37.6706 12.0608 37.6706 9.3724C37.6706 6.10919 40.6057 4.73438 43.2728 4.73438C45.1612 4.73438 46.9671 5.45284 48.0953 6.62277L46.1865 8.51117C45.5506 7.62862 44.4214 7.07425 43.1903 7.07425C41.9592 7.07425 40.5019 7.7102 40.5019 9.2287C40.5019 10.6239 41.6301 11.0754 43.1282 11.5686L43.7437 11.7531C46.2681 12.5531 48.1148 13.5386 48.1148 16.3086C48.1148 19.6534 45.3652 21.234 42.4709 21.234C40.398 21.234 38.3047 20.4135 37.0328 18.9358L37.0347 18.9349Z\" fill=\"white\"/><path d=\"M49.713 26V10.4052H52.2457V11.9005H52.306C53.004 10.8632 54.3399 10.1252 55.8955 10.1252C59.0067 10.1252 61.0211 12.5977 61.0211 15.5893C61.0211 18.5809 59.0465 21.1135 55.876 21.1135C54.4799 21.1135 53.1236 20.5156 52.3857 19.4384H52.3254V25.9991H49.713V26ZM58.4273 15.5902C58.4273 13.8548 57.35 12.2602 55.3161 12.2602C53.4416 12.2602 52.1854 13.8557 52.1854 15.6106C52.1854 17.3655 53.4416 18.9405 55.3161 18.9405C57.35 18.9405 58.4273 17.3451 58.4273 15.5902Z\" fill=\"white\"/><path d=\"M62.1743 15.6301C62.1743 12.34 64.567 10.0863 67.6587 10.0863C70.7504 10.0863 72.7844 12.2602 72.7844 15.5707C72.7844 15.8303 72.7844 16.0889 72.764 16.3281H64.7673C64.8275 17.8837 66.1829 19.0805 67.7987 19.0805C69.0753 19.0805 70.0125 18.4427 70.5511 17.6649L72.3858 18.9415C71.3085 20.4173 69.7335 21.1553 67.7589 21.1553C64.6282 21.1553 62.1752 19.0017 62.1752 15.631L62.1743 15.6301ZM70.2906 14.5927C70.2508 13.1372 69.3738 11.9997 67.6782 11.9997C65.9826 11.9997 64.8665 13.1966 64.7469 14.5927H70.2906Z\" fill=\"white\"/><path d=\"M73.9608 15.6301C73.9608 12.34 76.3535 10.0863 79.4452 10.0863C82.5369 10.0863 84.5709 12.2602 84.5709 15.5707C84.5709 15.8303 84.5709 16.0889 84.5514 16.3281H76.5547C76.615 17.8837 77.9703 19.0805 79.5861 19.0805C80.8627 19.0805 81.7999 18.4427 82.3385 17.6649L84.1732 18.9415C83.0959 20.4173 81.5209 21.1553 79.5463 21.1553C76.4156 21.1553 73.9627 19.0017 73.9627 15.631L73.9608 15.6301ZM82.0771 14.5927C82.0373 13.1372 81.1593 11.9997 79.4647 11.9997C77.7701 11.9997 76.653 13.1966 76.5334 14.5927H82.0771Z\" fill=\"white\"/><path d=\"M85.7418 15.5902C85.7418 12.5986 87.7563 10.1261 90.8869 10.1261C92.4221 10.1261 93.6792 10.8641 94.3773 11.8013H94.4375V5.2406H97.0305V20.8354H94.5775V19.3002H94.5377C93.7803 20.4766 92.3239 21.1154 90.9083 21.1154C87.6979 21.1154 85.7427 18.5827 85.7427 15.5911L85.7418 15.5902ZM94.5766 15.6096C94.5766 13.8547 93.3204 12.2593 91.4255 12.2593C89.4111 12.2593 88.3542 13.8547 88.3542 15.5892C88.3542 17.3237 89.4111 18.9396 91.4255 18.9396C93.3204 18.9396 94.5766 17.384 94.5766 15.6096Z\" fill=\"white\"/><path d=\"M98.2986 17.8633C98.2986 14.8318 101.848 14.3331 105.159 14.3331H105.299V14.0939C105.299 12.758 104.382 12.1193 103.026 12.1193C101.909 12.1193 100.872 12.5976 100.214 13.2558L98.8576 11.7401C99.9348 10.7027 101.55 10.0853 103.265 10.0853C106.475 10.0853 107.772 12.0201 107.772 14.4527V18.96C107.772 19.5978 107.812 20.3561 107.892 20.8345H105.539C105.459 20.4154 105.379 19.9167 105.379 19.4986H105.34C104.622 20.5359 103.465 21.094 102.029 21.094C100.394 21.094 98.2995 20.2764 98.2995 17.8633H98.2986ZM105.358 16.507V16.0082H104.899C103.004 16.0082 100.771 16.228 100.771 17.7835C100.771 18.8802 101.769 19.2195 102.685 19.2195C104.381 19.2195 105.358 18.083 105.358 16.507Z\" fill=\"white\"/><path d=\"M27.7595 6.12779C27.7595 2.74499 23.6017 0.00278114 18.5614 0H11.3869L16.4542 2.0256C15.49 2.22955 14.5547 2.6458 13.7203 3.28453L5.2406 10.3996H8.28225L22.8592 24.9765C23.5146 25.632 24.4027 25.9991 25.3288 25.9991H27.5964L21.6327 20.0354V16.4412C21.6327 14.0522 24.0328 11.5084 26.6332 11.5084C28.5151 11.5084 29.4616 13.1548 28.3399 14.8559C30.1448 14.0086 31.3166 12.9453 31.7347 11.3814C32.341 9.11659 30.3024 6.6182 27.7605 6.12686L27.7595 6.12779Z\" fill=\"white\"/><path d=\"M2.69123 13.7426L6.43558 15.2397L16.1724 24.9765C16.8278 25.6319 17.7159 26 18.642 26H20.9096L8.65216 13.7426H2.69031H2.69123Z\" fill=\"white\"/><path d=\"M0 17.828L3.89638 19.3864L9.48649 24.9765C10.1419 25.6319 11.03 25.9999 11.9561 25.9999H14.2237L6.0527 17.828H0Z\" fill=\"white\"/></svg>",
 	"inverse:true|logoLanguage:zh|symbol:false|subBrand:null": "<svg width=\"134\" height=\"20\" viewBox=\"0 0 134 20\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><g clip-path=\"url(#clip0_1_680)\"><path d=\"M1.04199 0V3.126H2.08399V10.418H19.168V0H1.04199ZM4.74999 2.292H9.47999V4.272H4.74999V2.292ZM4.74999 6.146H9.47999V8.126H4.74999V6.146ZM16.5 8.124H11.77V6.144H16.5V8.124ZM16.5 4.27H11.77V2.29H16.5V4.27Z\" fill=\"white\"/><path d=\"M15.0879 11.876L16.8919 15H19.5379L17.7339 11.876H15.0879Z\" fill=\"white\"/><path d=\"M15.4041 15L13.6001 11.876H10.9541L12.7581 15H15.4041Z\" fill=\"white\"/><path d=\"M2.76 20L4.77 12.5H2.01L0 20H2.76Z\" fill=\"white\"/><path d=\"M17.708 16.584V17.416H8.49998V14.374H9.41598V12.5H5.83398V18.124L7.70798 20H18.958L20.834 18.124V16.584H17.708Z\" fill=\"white\"/><path d=\"M68.8599 7.99L68.5099 8.342L62.2659 14.584H65.8019L70.2759 10.108L74.7519 14.584H78.2879L71.3599 7.658V6.042H75.9439V3.75H71.3599V1.874H72.2779V0H68.8599V3.75H64.2779V6.042H68.8599V7.99Z\" fill=\"white\"/><path d=\"M62.17 3.124L59.046 0H55.804L58.93 3.124H62.17Z\" fill=\"white\"/><path d=\"M75.152 17.416H62.482L60.986 14.824V5H56.194V7.5H58.278V15.6L53.876 20H57.412L59.742 17.67L61.088 20H61.946H76.402L78.278 18.126V16.584H75.152V17.416Z\" fill=\"white\"/><path d=\"M28.53 14.584L30.186 8.40601H27.426L25.77 14.584H28.53Z\" fill=\"white\"/><path d=\"M40.3521 0.00195312H32.9101L30.7881 2.29395H38.2281L40.3521 0.00195312Z\" fill=\"white\"/><path d=\"M45.142 17.418H36.186V12.722L46.196 2.71H48.268V0H45.166L36.186 8.98V5.874H37.102V4H33.478V11.688L29.056 16.11V16.114H29.052L25.166 20H28.908L33.478 15.43V18.126L35.352 20H46.392L48.268 18.126V16.584H45.142V17.418Z\" fill=\"white\"/><path d=\"M47.434 14.584L45.76 8.33398H43L44.674 14.584H47.434Z\" fill=\"white\"/><path d=\"M91.7539 7.952C91.5679 7.716 91.3259 7.528 91.0259 7.388C90.7259 7.248 90.4379 7.18 90.1599 7.18C90.0159 7.18 89.8699 7.192 89.7239 7.218C89.5759 7.244 89.4439 7.292 89.3259 7.364C89.2079 7.436 89.1079 7.528 89.0279 7.642C88.9479 7.756 88.9079 7.902 88.9079 8.078C88.9079 8.23 88.9399 8.356 89.0019 8.458C89.0659 8.56 89.1579 8.648 89.2799 8.724C89.4019 8.8 89.5479 8.87 89.7159 8.932C89.8839 8.996 90.0739 9.06 90.2859 9.128C90.5899 9.23 90.9059 9.342 91.2359 9.464C91.5659 9.586 91.8639 9.748 92.1339 9.952C92.4039 10.154 92.6279 10.406 92.8039 10.706C92.9819 11.006 93.0699 11.378 93.0699 11.826C93.0699 12.34 92.9759 12.786 92.7859 13.162C92.5959 13.538 92.3399 13.848 92.0199 14.092C91.6999 14.336 91.3319 14.518 90.9179 14.636C90.5039 14.754 90.0779 14.814 89.6399 14.814C88.9979 14.814 88.3779 14.702 87.7799 14.478C87.1799 14.254 86.6839 13.936 86.2859 13.522L87.7039 12.08C87.9239 12.35 88.2119 12.576 88.5699 12.758C88.9279 12.94 89.2859 13.03 89.6399 13.03C89.7999 13.03 89.9559 13.014 90.1079 12.98C90.2599 12.946 90.3919 12.892 90.5059 12.816C90.6199 12.74 90.7099 12.638 90.7779 12.512C90.8459 12.386 90.8799 12.234 90.8799 12.056C90.8799 11.878 90.8379 11.744 90.7539 11.626C90.6699 11.508 90.5499 11.4 90.3939 11.304C90.2379 11.208 90.0439 11.118 89.8119 11.038C89.5799 10.958 89.3159 10.872 89.0219 10.778C88.7359 10.686 88.4539 10.576 88.1799 10.448C87.9059 10.322 87.6619 10.16 87.4459 9.96C87.2299 9.762 87.0579 9.522 86.9279 9.238C86.7979 8.956 86.7319 8.612 86.7319 8.206C86.7319 7.708 86.8339 7.282 87.0359 6.928C87.2379 6.574 87.5039 6.282 87.8339 6.054C88.1639 5.826 88.5339 5.66 88.9479 5.554C89.3619 5.448 89.7779 5.396 90.1999 5.396C90.7059 5.396 91.2219 5.488 91.7499 5.674C92.2779 5.86 92.7399 6.134 93.1359 6.496L91.7559 7.952H91.7539Z\" fill=\"white\"/><path d=\"M101.434 10.148C101.296 9.746 101.098 9.394 100.84 9.09C100.582 8.786 100.266 8.546 99.8958 8.37C99.5238 8.192 99.1098 8.104 98.6538 8.104C98.1978 8.104 97.7878 8.198 97.4458 8.388C97.1038 8.578 96.8358 8.8 96.6438 9.054H96.6038V8.282H94.6318V17.704L96.7078 17.19V13.888H96.7338C96.9258 14.158 97.1958 14.37 97.5418 14.528C97.8878 14.682 98.2558 14.764 98.6438 14.764C99.1178 14.764 99.5378 14.67 99.9078 14.484C100.28 14.3 100.594 14.054 100.852 13.744C101.11 13.438 101.306 13.082 101.442 12.674C101.576 12.27 101.642 11.848 101.642 11.41C101.642 10.972 101.574 10.55 101.432 10.152L101.434 10.148ZM99.5358 12.008C99.4718 12.206 99.3818 12.38 99.2578 12.532C99.1338 12.684 98.9818 12.804 98.7958 12.9C98.6098 12.992 98.3938 13.038 98.1498 13.038C97.9058 13.038 97.7018 12.992 97.5158 12.9C97.3298 12.806 97.1718 12.684 97.0418 12.532C96.9098 12.38 96.8098 12.206 96.7378 12.014C96.6658 11.82 96.6298 11.622 96.6298 11.418C96.6298 11.214 96.6678 11.02 96.7378 10.824C96.8098 10.63 96.9098 10.456 97.0418 10.306C97.1718 10.154 97.3278 10.03 97.5158 9.938C97.7018 9.844 97.9118 9.798 98.1498 9.798C98.3878 9.798 98.6078 9.844 98.7958 9.938C98.9818 10.03 99.1338 10.15 99.2578 10.3C99.3818 10.446 99.4738 10.618 99.5358 10.81C99.5998 11.004 99.6298 11.202 99.6298 11.406C99.6298 11.61 99.5978 11.808 99.5358 12.008Z\" fill=\"white\"/><path d=\"M109.6 11.508V11.762C109.6 11.8461 109.596 11.926 109.588 12.002H105.02C105.036 12.18 105.09 12.34 105.178 12.482C105.266 12.626 105.38 12.75 105.52 12.856C105.66 12.962 105.816 13.0441 105.988 13.1021C106.16 13.1621 106.34 13.19 106.526 13.19C106.856 13.19 107.134 13.128 107.362 13.006C107.59 12.884 107.776 12.726 107.918 12.532L109.36 13.444C109.064 13.8741 108.674 14.2061 108.19 14.4381C107.704 14.6701 107.142 14.786 106.5 14.786C106.028 14.786 105.58 14.712 105.158 14.564C104.736 14.416 104.368 14.202 104.05 13.918C103.734 13.636 103.484 13.2881 103.304 12.8741C103.122 12.4601 103.032 11.988 103.032 11.456C103.032 10.924 103.12 10.476 103.298 10.058C103.476 9.64005 103.716 9.28605 104.02 8.99405C104.324 8.70205 104.682 8.47805 105.096 8.31605C105.51 8.15605 105.956 8.07605 106.438 8.07605C106.92 8.07605 107.328 8.15405 107.716 8.31005C108.104 8.46605 108.438 8.69205 108.716 8.98805C108.994 9.28405 109.212 9.64205 109.368 10.064C109.524 10.486 109.602 10.966 109.602 11.506L109.6 11.508ZM107.69 10.71C107.69 10.38 107.586 10.098 107.38 9.86205C107.174 9.62605 106.864 9.50805 106.45 9.50805C106.248 9.50805 106.062 9.54005 105.894 9.60205C105.726 9.66605 105.578 9.75205 105.452 9.86205C105.326 9.97205 105.224 10.1 105.148 10.248C105.072 10.396 105.03 10.55 105.022 10.71H107.692H107.69Z\" fill=\"white\"/><path d=\"M117.584 11.508V11.762C117.584 11.8461 117.58 11.926 117.572 12.002H113.004C113.02 12.18 113.074 12.34 113.162 12.482C113.25 12.626 113.364 12.75 113.504 12.856C113.644 12.962 113.8 13.0441 113.972 13.1021C114.144 13.1621 114.324 13.19 114.51 13.19C114.84 13.19 115.118 13.128 115.346 13.006C115.574 12.884 115.76 12.726 115.902 12.532L117.344 13.444C117.048 13.8741 116.658 14.2061 116.174 14.4381C115.688 14.6701 115.126 14.786 114.484 14.786C114.012 14.786 113.564 14.712 113.142 14.564C112.72 14.416 112.352 14.202 112.034 13.918C111.718 13.636 111.468 13.2881 111.288 12.8741C111.106 12.4601 111.016 11.988 111.016 11.456C111.016 10.924 111.104 10.476 111.282 10.058C111.46 9.64005 111.7 9.28605 112.004 8.99405C112.308 8.70205 112.666 8.47805 113.08 8.31605C113.494 8.15605 113.94 8.07605 114.422 8.07605C114.904 8.07605 115.312 8.15405 115.7 8.31005C116.088 8.46605 116.422 8.69205 116.7 8.98805C116.978 9.28405 117.196 9.64205 117.352 10.064C117.508 10.486 117.586 10.966 117.586 11.506L117.584 11.508ZM115.672 10.71C115.672 10.38 115.568 10.098 115.362 9.86205C115.156 9.62605 114.846 9.50805 114.432 9.50805C114.23 9.50805 114.044 9.54005 113.876 9.60205C113.708 9.66605 113.56 9.75205 113.434 9.86205C113.308 9.97205 113.206 10.1 113.13 10.248C113.054 10.396 113.012 10.55 113.004 10.71H115.674H115.672Z\" fill=\"white\"/><path d=\"M123.924 5.21603V8.95203H123.898C123.72 8.74003 123.47 8.54403 123.15 8.37003C122.828 8.19203 122.438 8.10403 121.974 8.10403C121.51 8.10403 121.106 8.19203 120.738 8.37003C120.37 8.54403 120.062 8.78603 119.804 9.09003C119.546 9.39403 119.348 9.74603 119.208 10.148C119.07 10.546 119.002 10.968 119.002 11.406C119.002 11.844 119.068 12.266 119.202 12.67C119.336 13.078 119.534 13.432 119.79 13.74C120.048 14.05 120.364 14.296 120.734 14.48C121.106 14.666 121.528 14.76 122.002 14.76C122.424 14.76 122.822 14.672 123.198 14.5C123.574 14.328 123.86 14.082 124.064 13.76H124.09V14.582H126V4.70203L123.928 5.21603H123.924ZM123.902 12.014C123.83 12.206 123.73 12.382 123.598 12.532C123.466 12.684 123.308 12.804 123.122 12.9C122.938 12.992 122.726 13.038 122.492 13.038C122.246 13.038 122.03 12.992 121.846 12.9C121.66 12.806 121.502 12.684 121.376 12.532C121.25 12.38 121.156 12.206 121.092 12.008C121.028 11.808 120.998 11.606 120.998 11.406C120.998 11.206 121.03 11.004 121.092 10.81C121.156 10.618 121.25 10.446 121.376 10.3C121.502 10.15 121.66 10.03 121.846 9.93803C122.03 9.84403 122.244 9.79803 122.492 9.79803C122.74 9.79803 122.94 9.84403 123.122 9.93803C123.308 10.03 123.466 10.154 123.598 10.306C123.73 10.458 123.83 10.63 123.902 10.824C123.974 11.018 124.008 11.216 124.008 11.418C124.008 11.62 123.974 11.82 123.902 12.014Z\" fill=\"white\"/><path d=\"M127.888 9.14005C128.26 8.78605 128.692 8.52005 129.186 8.34205C129.68 8.16405 130.184 8.07605 130.698 8.07605C131.212 8.07605 131.678 8.14205 132.046 8.27205C132.412 8.40205 132.71 8.60605 132.938 8.88005C133.166 9.15405 133.332 9.50005 133.438 9.91805C133.544 10.336 133.596 10.832 133.596 11.406V14.5821H131.698V13.912H131.66C131.5 14.174 131.256 14.376 130.932 14.52C130.608 14.664 130.254 14.736 129.876 14.736C129.622 14.736 129.362 14.702 129.092 14.634C128.822 14.566 128.576 14.456 128.352 14.304C128.128 14.152 127.944 13.9501 127.802 13.6961C127.658 13.4421 127.586 13.13 127.586 12.76C127.586 12.304 127.71 11.938 127.96 11.658C128.208 11.38 128.53 11.164 128.922 11.012C129.314 10.86 129.75 10.758 130.232 10.708C130.712 10.658 131.182 10.632 131.636 10.632V10.5301C131.636 10.2181 131.526 9.98805 131.306 9.84005C131.086 9.69205 130.816 9.61805 130.496 9.61805C130.2 9.61805 129.916 9.68205 129.642 9.80805C129.368 9.93405 129.134 10.086 128.94 10.264L127.89 9.13805L127.888 9.14005ZM131.698 11.836H131.432C131.204 11.836 130.974 11.846 130.742 11.868C130.51 11.89 130.304 11.93 130.122 11.988C129.94 12.048 129.79 12.134 129.672 12.2481C129.554 12.3621 129.494 12.5121 129.494 12.6981C129.494 12.8161 129.522 12.9181 129.576 13.002C129.63 13.0861 129.7 13.154 129.784 13.204C129.868 13.254 129.966 13.29 130.076 13.312C130.186 13.334 130.292 13.344 130.392 13.344C130.814 13.344 131.136 13.2281 131.36 12.9961C131.584 12.7641 131.696 12.45 131.696 12.054V11.838L131.698 11.836Z\" fill=\"white\"/></g><defs><clipPath id=\"clip0_1_680\"><rect width=\"133.596\" height=\"20\" fill=\"white\"/></clipPath></defs></svg>"
-}, Wr = (e) => Ur[`inverse:${e.inverse ?? "null"}|logoLanguage:${e.logoLanguage ?? "null"}|symbol:${e.symbol ?? "null"}|subBrand:${e.subBrand ?? "null"}`] ?? void 0, Gr = class extends M {
+}, Yr = (e) => Jr[`inverse:${e.inverse ?? "null"}|logoLanguage:${e.logoLanguage ?? "null"}|symbol:${e.symbol ?? "null"}|subBrand:${e.subBrand ?? "null"}`] ?? void 0, Z = class extends A {
 	constructor(...e) {
-		super(...e), this.subBrand = null, this.inverse = !1, this.noSymbol = !1, this.logoLanguage = "en", this.label = Fr;
+		super(...e), this.subBrand = null, this.inverse = !1, this.noSymbol = !1, this.logoLanguage = "en", this.label = Br;
 	}
 	static {
-		this.styles = P(o`
+		this.styles = M(o`
     :host {
       display: flex;
     }
@@ -3604,7 +3729,7 @@ var Ur = {
 		this.setAttribute("role", "img"), this.setAttribute("aria-label", this.label);
 	}
 	#e() {
-		return Wr({
+		return Yr({
 			subBrand: this.subBrand,
 			inverse: this.inverse,
 			symbol: !this.noSymbol,
@@ -3613,36 +3738,36 @@ var Ur = {
 	}
 	render() {
 		let e = this.#e();
-		return e ? O`${He(e)}` : A;
+		return e ? D`${We(e)}` : k;
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0,
 	attribute: "sub-brand"
-})], Gr.prototype, "subBrand", void 0), I([N({
+})], Z.prototype, "subBrand", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], Gr.prototype, "inverse", void 0), I([N({
+})], Z.prototype, "inverse", void 0), P([j({
 	type: Boolean,
 	reflect: !0,
 	attribute: "no-symbol"
-})], Gr.prototype, "noSymbol", void 0), I([N({
+})], Z.prototype, "noSymbol", void 0), P([j({
 	type: String,
 	reflect: !0,
 	attribute: "logo-language"
-})], Gr.prototype, "logoLanguage", void 0), I([N({ type: String })], Gr.prototype, "label", void 0), customElements.get("mi-speeda-logo") || customElements.define("mi-speeda-logo", Gr);
+})], Z.prototype, "logoLanguage", void 0), P([j({ type: String })], Z.prototype, "label", void 0), customElements.get("mi-speeda-logo") || customElements.define("mi-speeda-logo", Z);
 //#endregion
 //#region src/components/logo/uzabase-logos.ts
-var Kr = {
+var Xr = {
 	"inverse:false": "<svg width=\"118\" height=\"19\" viewBox=\"0 0 118 19\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><g clip-path=\"url(#clip0_1_705)\"><path d=\"M10.2549 0.167748H9.8355C8.91288 0.167748 8.57739 0.475856 8.57739 1.39676V13.4386C8.57739 15.1435 7.54351 16.2613 5.75649 16.2613C3.96946 16.2613 2.90649 15.1435 2.90649 13.4386V1.39676C2.90649 0.474144 2.59838 0.167748 1.67748 0.167748H1.25811C0.335496 0.167748 0 0.474144 0 1.39676V13.4386C0 15.1144 0.530631 16.4564 1.5936 17.4629C2.65487 18.4694 4.05162 18.9726 5.75649 18.9726C7.46135 18.9726 8.82901 18.4694 9.89198 17.4629C10.9532 16.429 11.4856 15.0887 11.4856 13.4386V1.39676C11.4856 0.474144 11.1775 0.167748 10.2566 0.167748H10.2549ZM27.4644 16.15H20.787L27.437 5.05811C27.9403 4.24847 28.1919 3.43712 28.1919 2.60009V1.53883C28.1919 0.504955 27.8838 0.169459 26.8499 0.169459H19.6128C18.6902 0.169459 18.3838 0.477568 18.3838 1.39847V1.6227C18.3838 2.54532 18.6919 2.85171 19.6128 2.85171H25.4241L18.8014 13.9436C18.2708 14.7259 18.0192 15.5646 18.0192 16.4581V17.4646C18.0192 18.4985 18.3547 18.834 19.3886 18.834H27.4627C28.3853 18.834 28.6917 18.5259 28.6917 17.605V17.3807C28.6917 16.4581 28.3836 16.1517 27.4627 16.1517L27.4644 16.15ZM43.195 1.50973C42.9434 0.475856 42.5532 0.167748 41.5193 0.167748H39.4806C38.4468 0.167748 38.0565 0.475856 37.8049 1.50973L34.1726 17.6032C33.9484 18.4968 34.2565 18.8323 35.1791 18.8323H35.6532C36.6306 18.8323 36.9661 18.5806 37.1904 17.6032L37.8049 14.7532H43.1968L43.8404 17.6032C44.0355 18.5806 44.371 18.8323 45.3484 18.8323H45.8516C46.7742 18.8323 47.0532 18.4968 46.829 17.6032L43.1968 1.50973H43.195ZM38.3886 12.0984L38.9192 9.64036C39.5611 6.65 40.0643 3.85649 40.4563 1.31459C40.7079 2.90649 41.2386 5.67261 42.0773 9.66946L42.6079 12.1001H38.3886V12.0984ZM61.8869 9.24838C63.4514 8.82901 64.5127 7.6 64.5127 5.39189V4.77739C64.5127 1.98387 62.5562 0.167748 59.0078 0.167748H54.6498C53.6159 0.167748 53.2805 0.503243 53.2805 1.53712V17.4629C53.2805 18.4968 53.6159 18.8323 54.6498 18.8323H59.2595C62.9191 18.8323 65.016 16.8758 65.016 13.8871V13.2726C65.016 10.842 63.8143 9.50171 61.8869 9.25009V9.24838ZM56.1596 2.79351H58.9257C60.6853 2.79351 61.6644 3.60315 61.6644 5.02901V5.58703C61.6644 7.17892 60.9096 8.10153 58.6741 8.10153H56.1596V2.79351ZM62.1386 13.7194C62.1386 15.2565 61.1047 16.2065 58.9805 16.2065H56.1578V10.6742H59.0078C61.103 10.6742 62.1369 11.513 62.1369 13.1887V13.7194H62.1386ZM79.9078 1.50973C79.6562 0.475856 79.266 0.167748 78.2321 0.167748H76.1934C75.1596 0.167748 74.7693 0.475856 74.5177 1.50973L70.8854 17.6032C70.6612 18.4968 70.9693 18.8323 71.8919 18.8323H72.366C73.3434 18.8323 73.6789 18.5806 73.9032 17.6032L74.5177 14.7532H79.9096L80.5532 17.6032C80.7483 18.5806 81.0838 18.8323 82.0612 18.8323H82.5644C83.487 18.8323 83.766 18.4968 83.5418 17.6032L79.9096 1.50973H79.9078ZM75.1014 12.0984L75.632 9.64036C76.2739 6.65 76.7771 3.85649 77.1691 1.31459C77.4207 2.90649 77.9514 5.67261 78.7901 9.66946L79.3207 12.1001H75.1014V12.0984ZM95.2191 7.99027C93.5707 7.23541 92.2578 6.25802 92.2578 4.91604C92.2578 3.49189 93.2078 2.65315 94.7997 2.65315C96.4755 2.65315 97.5094 3.60315 97.5933 5.08378C97.6771 5.86604 98.0126 6.09027 98.9061 6.09027H99.3255C100.192 6.09027 100.5 5.78216 100.5 5.02901C100.5 3.54838 99.9691 2.34676 98.9352 1.42414C97.9014 0.474144 96.532 0 94.8271 0C93.2352 0 91.8932 0.474144 90.8594 1.39676C89.8255 2.31937 89.2949 3.51928 89.2949 5.00162C89.2384 8.43874 92.3691 9.83549 94.7433 10.8129C96.419 11.5113 97.7336 12.5177 97.7336 13.8854C97.7336 15.4225 96.6433 16.316 94.9401 16.316C93.0401 16.316 91.9224 15.1983 91.8385 13.7177C91.7546 12.9354 91.4465 12.6838 90.553 12.6838H90.1062C89.2966 12.6838 88.9046 13.0193 88.9046 13.6903C88.9046 15.2548 89.4626 16.5403 90.6095 17.5177C91.7546 18.495 93.1805 18.9709 94.9401 18.9709C96.6997 18.9709 98.0691 18.4968 99.103 17.5468C100.137 16.5968 100.667 15.3386 100.667 13.8032C100.695 10.45 97.6224 8.99847 95.2191 7.99198V7.99027ZM115.811 2.85C116.734 2.85 117.04 2.54189 117.04 1.62099V1.39676C117.04 0.474144 116.732 0.167748 115.811 0.167748H108.909C107.876 0.167748 107.54 0.503243 107.54 1.53712V17.4629C107.54 18.4968 107.876 18.8323 108.909 18.8323H115.811C116.734 18.8323 117.04 18.5241 117.04 17.6032V17.379C117.04 16.4564 116.732 16.15 115.811 16.15H110.419V10.842H115.226C116.148 10.842 116.427 10.563 116.427 9.58387V9.35964C116.427 8.43703 116.148 8.13063 115.226 8.13063H110.419V2.85H115.811Z\" fill=\"black\"/></g><defs><clipPath id=\"clip0_1_705\"><rect width=\"117.081\" height=\"19\" fill=\"white\"/></clipPath></defs></svg>",
 	"inverse:true": "<svg width=\"118\" height=\"19\" viewBox=\"0 0 118 19\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><g clip-path=\"url(#clip0_1_707)\"><path d=\"M10.2549 0.167748H9.8355C8.91288 0.167748 8.57739 0.475856 8.57739 1.39676V13.4386C8.57739 15.1435 7.54351 16.2613 5.75649 16.2613C3.96946 16.2613 2.90649 15.1435 2.90649 13.4386V1.39676C2.90649 0.474144 2.59838 0.167748 1.67748 0.167748H1.25811C0.335496 0.167748 0 0.474144 0 1.39676V13.4386C0 15.1144 0.530631 16.4564 1.5936 17.4629C2.65487 18.4694 4.05162 18.9726 5.75649 18.9726C7.46135 18.9726 8.82901 18.4694 9.89198 17.4629C10.9532 16.429 11.4856 15.0887 11.4856 13.4386V1.39676C11.4856 0.474144 11.1775 0.167748 10.2566 0.167748H10.2549ZM27.4644 16.15H20.787L27.437 5.05811C27.9403 4.24847 28.1919 3.43712 28.1919 2.60009V1.53883C28.1919 0.504955 27.8838 0.169459 26.8499 0.169459H19.6128C18.6902 0.169459 18.3838 0.477568 18.3838 1.39847V1.6227C18.3838 2.54532 18.6919 2.85171 19.6128 2.85171H25.4241L18.8014 13.9436C18.2708 14.7259 18.0192 15.5646 18.0192 16.4581V17.4646C18.0192 18.4985 18.3547 18.834 19.3886 18.834H27.4627C28.3853 18.834 28.6917 18.5259 28.6917 17.605V17.3807C28.6917 16.4581 28.3836 16.1517 27.4627 16.1517L27.4644 16.15ZM43.195 1.50973C42.9434 0.475856 42.5532 0.167748 41.5193 0.167748H39.4806C38.4468 0.167748 38.0565 0.475856 37.8049 1.50973L34.1726 17.6032C33.9484 18.4968 34.2565 18.8323 35.1791 18.8323H35.6532C36.6306 18.8323 36.9661 18.5806 37.1904 17.6032L37.8049 14.7532H43.1968L43.8404 17.6032C44.0355 18.5806 44.371 18.8323 45.3484 18.8323H45.8516C46.7742 18.8323 47.0532 18.4968 46.829 17.6032L43.1968 1.50973H43.195ZM38.3886 12.0984L38.9192 9.64036C39.5611 6.65 40.0643 3.85649 40.4563 1.31459C40.7079 2.90649 41.2386 5.67261 42.0773 9.66946L42.6079 12.1001H38.3886V12.0984ZM61.8869 9.24838C63.4514 8.82901 64.5127 7.6 64.5127 5.39189V4.77739C64.5127 1.98387 62.5562 0.167748 59.0078 0.167748H54.6498C53.6159 0.167748 53.2805 0.503243 53.2805 1.53712V17.4629C53.2805 18.4968 53.6159 18.8323 54.6498 18.8323H59.2595C62.9191 18.8323 65.016 16.8758 65.016 13.8871V13.2726C65.016 10.842 63.8143 9.50171 61.8869 9.25009V9.24838ZM56.1596 2.79351H58.9257C60.6853 2.79351 61.6644 3.60315 61.6644 5.02901V5.58703C61.6644 7.17892 60.9096 8.10153 58.6741 8.10153H56.1596V2.79351ZM62.1386 13.7194C62.1386 15.2565 61.1047 16.2065 58.9805 16.2065H56.1578V10.6742H59.0078C61.103 10.6742 62.1369 11.513 62.1369 13.1887V13.7194H62.1386ZM79.9078 1.50973C79.6562 0.475856 79.266 0.167748 78.2321 0.167748H76.1934C75.1596 0.167748 74.7693 0.475856 74.5177 1.50973L70.8854 17.6032C70.6612 18.4968 70.9693 18.8323 71.8919 18.8323H72.366C73.3434 18.8323 73.6789 18.5806 73.9032 17.6032L74.5177 14.7532H79.9096L80.5532 17.6032C80.7483 18.5806 81.0838 18.8323 82.0612 18.8323H82.5644C83.487 18.8323 83.766 18.4968 83.5418 17.6032L79.9096 1.50973H79.9078ZM75.1014 12.0984L75.632 9.64036C76.2739 6.65 76.7771 3.85649 77.1691 1.31459C77.4207 2.90649 77.9514 5.67261 78.7901 9.66946L79.3207 12.1001H75.1014V12.0984ZM95.2191 7.99027C93.5707 7.23541 92.2578 6.25802 92.2578 4.91604C92.2578 3.49189 93.2078 2.65315 94.7997 2.65315C96.4755 2.65315 97.5094 3.60315 97.5933 5.08378C97.6771 5.86604 98.0126 6.09027 98.9061 6.09027H99.3255C100.192 6.09027 100.5 5.78216 100.5 5.02901C100.5 3.54838 99.9691 2.34676 98.9352 1.42414C97.9014 0.474144 96.532 0 94.8271 0C93.2352 0 91.8932 0.474144 90.8594 1.39676C89.8255 2.31937 89.2949 3.51928 89.2949 5.00162C89.2384 8.43874 92.3691 9.83549 94.7433 10.8129C96.419 11.5113 97.7336 12.5177 97.7336 13.8854C97.7336 15.4225 96.6433 16.316 94.9401 16.316C93.0401 16.316 91.9224 15.1983 91.8385 13.7177C91.7546 12.9354 91.4465 12.6838 90.553 12.6838H90.1062C89.2966 12.6838 88.9046 13.0193 88.9046 13.6903C88.9046 15.2548 89.4626 16.5403 90.6095 17.5177C91.7546 18.495 93.1805 18.9709 94.9401 18.9709C96.6997 18.9709 98.0691 18.4968 99.103 17.5468C100.137 16.5968 100.667 15.3386 100.667 13.8032C100.695 10.45 97.6224 8.99847 95.2191 7.99198V7.99027ZM115.811 2.85C116.734 2.85 117.04 2.54189 117.04 1.62099V1.39676C117.04 0.474144 116.732 0.167748 115.811 0.167748H108.909C107.876 0.167748 107.54 0.503243 107.54 1.53712V17.4629C107.54 18.4968 107.876 18.8323 108.909 18.8323H115.811C116.734 18.8323 117.04 18.5241 117.04 17.6032V17.379C117.04 16.4564 116.732 16.15 115.811 16.15H110.419V10.842H115.226C116.148 10.842 116.427 10.563 116.427 9.58387V9.35964C116.427 8.43703 116.148 8.13063 115.226 8.13063H110.419V2.85H115.811Z\" fill=\"white\"/></g><defs><clipPath id=\"clip0_1_707\"><rect width=\"117.081\" height=\"19\" fill=\"white\"/></clipPath></defs></svg>"
-}, qr = (e) => Kr[`inverse:${e.inverse ?? "null"}`] ?? void 0, Jr = class extends M {
+}, Zr = (e) => Xr[`inverse:${e.inverse ?? "null"}`] ?? void 0, Qr = class extends A {
 	constructor(...e) {
-		super(...e), this.inverse = !1, this.label = Ir;
+		super(...e), this.inverse = !1, this.label = Vr;
 	}
 	static {
-		this.styles = P(o`
+		this.styles = M(o`
     :host {
       display: flex;
     }
@@ -3652,59 +3777,59 @@ var Kr = {
 		this.setAttribute("role", "img"), this.setAttribute("aria-label", this.label);
 	}
 	#e() {
-		return qr({ inverse: this.inverse });
+		return Zr({ inverse: this.inverse });
 	}
 	render() {
 		let e = this.#e();
-		return e ? O`${He(e)}` : A;
+		return e ? D`${We(e)}` : k;
 	}
 };
-I([N({
+P([j({
 	type: Boolean,
 	reflect: !0
-})], Jr.prototype, "inverse", void 0), I([N({ type: String })], Jr.prototype, "label", void 0), customElements.get("mi-uzabase-logo") || customElements.define("mi-uzabase-logo", Jr);
+})], Qr.prototype, "inverse", void 0), P([j({ type: String })], Qr.prototype, "label", void 0), customElements.get("mi-uzabase-logo") || customElements.define("mi-uzabase-logo", Qr);
 //#endregion
 //#region src/components/menu/control-menu/styles.css?inline
-var Yr = ":host{background-color:#fff;border-radius:6px;padding:8px 0;display:block;box-shadow:0 5px 9px 2px #00000021}", Xr = class extends M {
+var $r = ":host{background-color:#fff;border-radius:6px;padding:8px 0;display:block;box-shadow:0 5px 9px 2px #00000021}", ei = class extends A {
 	static {
-		this.styles = P(a(Yr));
+		this.styles = M(a($r));
 	}
 	render() {
-		return O`<slot></slot>`;
+		return D`<slot></slot>`;
 	}
-}, Zr = class extends Xr {};
-customElements.get("mi-control-menu") || customElements.define("mi-control-menu", Xr), customElements.get("sp-control-menu") || customElements.define("sp-control-menu", Zr);
+}, ti = class extends ei {};
+customElements.get("mi-control-menu") || customElements.define("mi-control-menu", ei), customElements.get("sp-control-menu") || customElements.define("sp-control-menu", ti);
 //#endregion
 //#region src/components/menu/control-menu-item/styles.css?inline
-var Qr = ":host{box-sizing:border-box;cursor:pointer;color:#000000d6;justify-content:space-between;align-items:center;column-gap:8px;min-height:32px;padding:4px 12px 4px 16px;font-size:14px;display:flex}:host .icon{width:24px;height:24px;display:none}:host([selected]){background-color:#f0f6ff}:host([selected]) .icon{display:block}:host([selected]:hover){background-color:#e3efff}:host([selected]:active){background-color:#d4e6ff}:host([disabled]){cursor:not-allowed;color:#00000059;background-color:#0000}:host([disabled]:hover),:host([disabled]:active){background-color:#0000}:host([disabled]:focus){border:none;padding:4px 12px 4px 16px}:host(:hover){background-color:#f8f8f8}:host(:active){background-color:#0000000d}:host(:focus){box-sizing:border-box;border:2px solid #191919;outline:none;padding:2px 10px 2px 14px}", $r = class extends M {
+var ni = ":host{box-sizing:border-box;cursor:pointer;color:#000000d6;justify-content:space-between;align-items:center;column-gap:8px;min-height:32px;padding:4px 12px 4px 16px;font-size:14px;display:flex}:host .icon{width:24px;height:24px;display:none}:host([selected]){background-color:#f0f6ff}:host([selected]) .icon{display:block}:host([selected]:hover){background-color:#e3efff}:host([selected]:active){background-color:#d4e6ff}:host([disabled]){cursor:not-allowed;color:#00000059;background-color:#0000}:host([disabled]:hover),:host([disabled]:active){background-color:#0000}:host([disabled]:focus){border:none;padding:4px 12px 4px 16px}:host(:hover){background-color:#f8f8f8}:host(:active){background-color:#0000000d}:host(:focus){box-sizing:border-box;border:2px solid #191919;outline:none;padding:2px 10px 2px 14px}", ri = class extends A {
 	constructor(...e) {
 		super(...e), this.text = "", this.selected = !1, this.disabled = !1;
 	}
 	static {
-		this.styles = P(a(Qr));
+		this.styles = M(a(ni));
 	}
 	render() {
-		return O`
+		return D`
       <span class="text">${this.text}</span>
       <mi-icon class="icon" type="check-small"></mi-icon>
     `;
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0
-})], $r.prototype, "text", void 0), I([N({
+})], ri.prototype, "text", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], $r.prototype, "selected", void 0), I([N({
+})], ri.prototype, "selected", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], $r.prototype, "disabled", void 0);
-var ei = class extends $r {};
-customElements.get("mi-control-menu-item") || customElements.define("mi-control-menu-item", $r), customElements.get("sp-control-menu-item") || customElements.define("sp-control-menu-item", ei);
+})], ri.prototype, "disabled", void 0);
+var ii = class extends ri {};
+customElements.get("mi-control-menu-item") || customElements.define("mi-control-menu-item", ri), customElements.get("sp-control-menu-item") || customElements.define("sp-control-menu-item", ii);
 //#endregion
 //#region src/components/radio-button/radio-button-text.styles.ts
-var ti = o`
+var ai = o`
   :host {
     display: inline-block;
 
@@ -3835,9 +3960,9 @@ var ti = o`
   :host(:not([disabled])) .base:active .input:checked + .radio::after {
     background-color: var(--color-semantic-surface-checked-active);
   }
-`, ni = class extends M {
+`, oi = class extends A {
 	static {
-		this.styles = P(ti);
+		this.styles = M(ai);
 	}
 	#e;
 	static {
@@ -3861,7 +3986,7 @@ var ti = o`
 	}
 	#n;
 	render() {
-		return O`
+		return D`
       <label class="base">
         <input
           type="radio"
@@ -3881,24 +4006,24 @@ var ti = o`
     `;
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0
-})], ni.prototype, "value", void 0), I([N({
+})], oi.prototype, "value", void 0), P([j({
 	type: String,
 	reflect: !0
-})], ni.prototype, "name", void 0), I([N({
+})], oi.prototype, "name", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], ni.prototype, "checked", void 0), I([N({
+})], oi.prototype, "checked", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], ni.prototype, "disabled", void 0);
-var ri = class extends ni {};
-customElements.get("mi-radio-button-text") || customElements.define("mi-radio-button-text", ni), customElements.get("sp-radio-button-text") || customElements.define("sp-radio-button-text", ri);
+})], oi.prototype, "disabled", void 0);
+var si = class extends oi {};
+customElements.get("mi-radio-button-text") || customElements.define("mi-radio-button-text", oi), customElements.get("sp-radio-button-text") || customElements.define("sp-radio-button-text", si);
 //#endregion
 //#region src/components/snackbar/snackbar.styles.ts
-var ii = o`
+var ci = o`
   :host {
     display: block;
     box-sizing: border-box;
@@ -4025,16 +4150,16 @@ var ii = o`
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
-`, ai = ["small", "medium"];
-function oi(e) {
-	return typeof e == "string" && ai.includes(e) ? e : "small";
+`, li = ["small", "medium"];
+function ui(e) {
+	return typeof e == "string" && li.includes(e) ? e : "small";
 }
-var si = class extends M {
+var di = class extends A {
 	constructor(...e) {
 		super(...e), this.size = "small", this.autoHideTimeout = 5e3, this.entering = !0, this.exiting = !1, this.exitRemoved = !1, this.exitTransitionSeen = /* @__PURE__ */ new Set();
 	}
 	static {
-		this.styles = P(ii);
+		this.styles = M(ci);
 	}
 	clearAutoHideTimer() {
 		this.autoHideTimerId !== void 0 && (clearTimeout(this.autoHideTimerId), this.autoHideTimerId = void 0);
@@ -4088,8 +4213,8 @@ var si = class extends M {
 		return this.exiting ? !1 : (this.beginClose(), !0);
 	}
 	render() {
-		let e = oi(this.size), t = e === "small" ? "cross-small" : "cross", n = e === "small" ? "small" : "medium";
-		return O`
+		let e = ui(this.size), t = e === "small" ? "cross-small" : "cross", n = e === "small" ? "small" : "medium";
+		return D`
       <div
         class="root ${e}"
         ?data-starting-style=${this.entering}
@@ -4114,16 +4239,16 @@ var si = class extends M {
     `;
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0
-})], si.prototype, "size", void 0), I([N({
+})], di.prototype, "size", void 0), P([j({
 	type: Number,
 	attribute: "auto-hide-timeout"
-})], si.prototype, "autoHideTimeout", void 0), I([Fe()], si.prototype, "entering", void 0), I([Fe()], si.prototype, "exiting", void 0), customElements.get("mi-snackbar") || customElements.define("mi-snackbar", si);
+})], di.prototype, "autoHideTimeout", void 0), P([Le()], di.prototype, "entering", void 0), P([Le()], di.prototype, "exiting", void 0), customElements.get("mi-snackbar") || customElements.define("mi-snackbar", di);
 //#endregion
 //#region src/components/snackbar/snackbar-viewport.styles.ts
-var ci = o`
+var fi = o`
   :host {
     display: flex;
     flex-direction: column;
@@ -4171,32 +4296,32 @@ var ci = o`
       align-self: center;
     }
   }
-`, li = class extends M {
+`, pi = class extends A {
 	static {
-		this.styles = P(ci);
+		this.styles = M(fi);
 	}
 	render() {
-		return O`<slot></slot>`;
+		return D`<slot></slot>`;
 	}
 };
-customElements.get("mi-snackbar-viewport") || customElements.define("mi-snackbar-viewport", li);
+customElements.get("mi-snackbar-viewport") || customElements.define("mi-snackbar-viewport", pi);
 //#endregion
 //#region src/components/text-field/text-field/error-text/styles.css?inline
-var ui = ":host .container{color:#c92812;align-items:center;gap:2px;padding-top:8px;display:flex}:host .container>.text{font-weight:var(--font-weight-normal);font-size:14px}:host .container .icon{width:21px;height:21px}:host .container.none{display:none}", di = class extends M {
+var mi = ":host .container{color:#c92812;align-items:center;gap:2px;padding-top:8px;display:flex}:host .container>.text{font-weight:var(--font-weight-normal);font-size:14px}:host .container .icon{width:21px;height:21px}:host .container.none{display:none}", hi = class extends A {
 	constructor(...e) {
 		super(...e), this.text = "";
 	}
 	static {
-		this.styles = P(a(ui));
+		this.styles = M(a(mi));
 	}
 	#e() {
-		return jr({
+		return Ir({
 			container: !0,
 			none: !this.text
 		});
 	}
 	render() {
-		return O`
+		return D`
       <div class="${this.#e()}" role="error">
         <mi-icon class="icon" type="error-fill"></mi-icon>
         <span class="text">${this.text}</span>
@@ -4204,17 +4329,17 @@ var ui = ":host .container{color:#c92812;align-items:center;gap:2px;padding-top:
     `;
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0
-})], di.prototype, "text", void 0);
-var fi = class extends di {};
-customElements.get("mi-text-field-error-text") || customElements.define("mi-text-field-error-text", di), customElements.get("sp-text-field-error-text") || customElements.define("sp-text-field-error-text", fi);
+})], hi.prototype, "text", void 0);
+var gi = class extends hi {};
+customElements.get("mi-text-field-error-text") || customElements.define("mi-text-field-error-text", hi), customElements.get("sp-text-field-error-text") || customElements.define("sp-text-field-error-text", gi);
 //#endregion
 //#region src/components/text-field/text-field/styles.css?inline
-var pi = ".input{box-sizing:border-box;width:100%;height:48px;font-weight:var(--font-weight-normal);background:#fff;border:1px solid #b6b6b6;border-radius:6px;padding:4px 12px;font-size:16px;line-height:24}.input::placeholder{color:#0000008a}.input[disabled]{color:#000000ad;background-color:#0000000d;border-color:#e5e5e5}.input[disabled]::placeholder{color:#00000059}.input[disabled]:hover{border-color:#e5e5e5}.input:hover{border-color:#0000008f}.input:focus-visible{outline-offset:1px;outline:3px solid canvastext;box-shadow:0 0 0 2px #fff,0 0 0 4px #282828}.input.error{border-color:#db351f}", Q = class extends M {
+var _i = ".input{box-sizing:border-box;width:100%;height:48px;font-weight:var(--font-weight-normal);background:#fff;border:1px solid #b6b6b6;border-radius:6px;padding:4px 12px;font-size:16px;line-height:24}.input::placeholder{color:#0000008a}.input[disabled]{color:#000000ad;background-color:#0000000d;border-color:#e5e5e5}.input[disabled]::placeholder{color:#00000059}.input[disabled]:hover{border-color:#e5e5e5}.input:hover{border-color:#0000008f}.input:focus-visible{outline-offset:1px;outline:3px solid canvastext;box-shadow:0 0 0 2px #fff,0 0 0 4px #282828}.input.error{border-color:#db351f}", Q = class extends A {
 	static {
-		this.styles = P(a(pi));
+		this.styles = M(a(_i));
 	}
 	static {
 		this.formAssociated = !0;
@@ -4226,7 +4351,7 @@ var pi = ".input{box-sizing:border-box;width:100%;height:48px;font-weight:var(--
 		super.updated(e), e.has("value") && this.internals.setFormValue(this.value);
 	}
 	#e() {
-		return jr({
+		return Ir({
 			input: !0,
 			error: this.error && !this.disabled
 		});
@@ -4245,7 +4370,7 @@ var pi = ".input{box-sizing:border-box;width:100%;height:48px;font-weight:var(--
 		}
 	}
 	render() {
-		return O`
+		return D`
       <input
         class="${this.#e()}"
         type="${this.type}"
@@ -4265,42 +4390,42 @@ var pi = ".input{box-sizing:border-box;width:100%;height:48px;font-weight:var(--
     `;
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0
-})], Q.prototype, "error", void 0), I([N({
+})], Q.prototype, "error", void 0), P([j({
 	type: String,
 	reflect: !0
-})], Q.prototype, "placeholder", void 0), I([N({
+})], Q.prototype, "placeholder", void 0), P([j({
 	type: String,
 	reflect: !0
-})], Q.prototype, "autocomplete", void 0), I([N({
+})], Q.prototype, "autocomplete", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], Q.prototype, "disabled", void 0), I([N({
+})], Q.prototype, "disabled", void 0), P([j({
 	type: String,
 	reflect: !0
-})], Q.prototype, "name", void 0), I([N({
+})], Q.prototype, "name", void 0), P([j({
 	type: String,
 	reflect: !0
-})], Q.prototype, "value", void 0), I([N({
+})], Q.prototype, "value", void 0), P([j({
 	type: String,
 	reflect: !0
-})], Q.prototype, "type", void 0), I([N({
+})], Q.prototype, "type", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], Q.prototype, "autofocus", void 0), I([N({
+})], Q.prototype, "autofocus", void 0), P([j({
 	type: Boolean,
 	attribute: "submit-on-enter",
 	reflect: !0
 })], Q.prototype, "submitOnEnter", void 0);
-var mi = class extends Q {};
-customElements.get("mi-text-field") || customElements.define("mi-text-field", Q), customElements.get("sp-text-field") || customElements.define("sp-text-field", mi);
+var vi = class extends Q {};
+customElements.get("mi-text-field") || customElements.define("mi-text-field", Q), customElements.get("sp-text-field") || customElements.define("sp-text-field", vi);
 //#endregion
 //#region src/components/text-field/text-field-unit/styles.css?inline
-var hi = ":host .label{text-align:left;margin-bottom:8px}:host .label.none{display:none}", $ = class extends M {
+var yi = ":host .label{text-align:left;margin-bottom:8px}:host .label.none{display:none}", $ = class extends A {
 	static {
-		this.styles = P(a(hi));
+		this.styles = M(a(yi));
 	}
 	static {
 		this.formAssociated = !0;
@@ -4312,7 +4437,7 @@ var hi = ":host .label{text-align:left;margin-bottom:8px}:host .label.none{displ
 		super.updated(e), e.has("value") && this.internals.setFormValue(this.value);
 	}
 	#e() {
-		return jr({
+		return Ir({
 			label: !0,
 			none: !this.text && !this.supportText
 		});
@@ -4328,7 +4453,7 @@ var hi = ":host .label{text-align:left;margin-bottom:8px}:host .label.none{displ
 		}
 	}
 	render() {
-		return O`
+		return D`
       <fieldset>
         <mi-label-unit
           class="${this.#e()}"
@@ -4351,43 +4476,43 @@ var hi = ":host .label{text-align:left;margin-bottom:8px}:host .label.none{displ
     `;
 	}
 };
-I([N({
+P([j({
 	type: String,
 	reflect: !0
-})], $.prototype, "text", void 0), I([N({
+})], $.prototype, "text", void 0), P([j({
 	type: String,
 	reflect: !0
-})], $.prototype, "error", void 0), I([N({
+})], $.prototype, "error", void 0), P([j({
 	type: String,
 	reflect: !0
-})], $.prototype, "placeholder", void 0), I([N({
+})], $.prototype, "placeholder", void 0), P([j({
 	type: String,
 	attribute: "support-text",
 	reflect: !0
-})], $.prototype, "supportText", void 0), I([N({
+})], $.prototype, "supportText", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], $.prototype, "disabled", void 0), I([N({
+})], $.prototype, "disabled", void 0), P([j({
 	type: String,
 	reflect: !0
-})], $.prototype, "name", void 0), I([N({
+})], $.prototype, "name", void 0), P([j({
 	type: String,
 	reflect: !0
-})], $.prototype, "value", void 0), I([N({
+})], $.prototype, "value", void 0), P([j({
 	type: String,
 	reflect: !0
-})], $.prototype, "type", void 0), I([N({
+})], $.prototype, "type", void 0), P([j({
 	type: String,
 	reflect: !0
-})], $.prototype, "autocomplete", void 0), I([N({
+})], $.prototype, "autocomplete", void 0), P([j({
 	type: Boolean,
 	reflect: !0
-})], $.prototype, "autofocus", void 0), I([N({
+})], $.prototype, "autofocus", void 0), P([j({
 	type: Boolean,
 	attribute: "submit-on-enter",
 	reflect: !0
 })], $.prototype, "submitOnEnter", void 0);
-var gi = class extends $ {};
-customElements.get("mi-text-field-unit") || customElements.define("mi-text-field-unit", $), customElements.get("sp-text-field-unit") || customElements.define("sp-text-field-unit", gi);
+var bi = class extends $ {};
+customElements.get("mi-text-field-unit") || customElements.define("mi-text-field-unit", $), customElements.get("sp-text-field-unit") || customElements.define("sp-text-field-unit", bi);
 //#endregion
-export { pr as MiActionDialog, gt as MiAiButton, L as MiAvatar, ar as MiButton, Y as MiCheckbox, X as MiCheckboxText, Xr as MiControlMenu, $r as MiControlMenuItem, _t as MiDangerButton, xr as MiFloatingButton, gr as MiFormDialog, $e as MiIcon, rr as MiIconButton, Dr as MiIconColor, yr as MiInformationDialog, Ar as MiInlineNotification, Nr as MiLabelUnit, ct as MiLoading, Vr as MiLogo, ir as MiNeutralButton, ni as MiRadioButtonText, si as MiSnackbar, li as MiSnackbarViewport, Gr as MiSpeedaLogo, Q as MiTextField, di as MiTextFieldErrorText, $ as MiTextFieldUnit, $n as MiTooltip, Jr as MiUzabaseLogo, ot as SpAvatar, or as SpButton, lr as SpCheckbox, dr as SpCheckboxText, Zr as SpControlMenu, ei as SpControlMenuItem, Sr as SpFloatingButton, et as SpIcon, Pr as SpLabelUnit, lt as SpLoading, Hr as SpLogo, ri as SpRadioButtonText, mi as SpTextField, fi as SpTextFieldErrorText, gi as SpTextFieldUnit, mr as formDialogSizes, nr as iconButtonSizes, tr as iconButtonVariants, _r as informationDialogSizes, ai as snackbarSizes };
+export { vr as MiActionDialog, vt as MiAiButton, F as MiAvatar, or as MiButton, J as MiCheckbox, Y as MiCheckboxText, ei as MiControlMenu, ri as MiControlMenuItem, yt as MiDangerButton, Er as MiFloatingButton, xr as MiFormDialog, tt as MiIcon, q as MiIconButton, Mr as MiIconColor, wr as MiInformationDialog, Fr as MiInlineNotification, mr as MiInputChip, gr as MiInputChipGroup, Rr as MiLabelUnit, ut as MiLoading, Kr as MiLogo, ar as MiNeutralButton, oi as MiRadioButtonText, di as MiSnackbar, pi as MiSnackbarViewport, Z as MiSpeedaLogo, Q as MiTextField, hi as MiTextFieldErrorText, $ as MiTextFieldUnit, tr as MiTooltip, Qr as MiUzabaseLogo, ct as SpAvatar, sr as SpButton, ur as SpCheckbox, fr as SpCheckboxText, ti as SpControlMenu, ii as SpControlMenuItem, Dr as SpFloatingButton, nt as SpIcon, zr as SpLabelUnit, dt as SpLoading, qr as SpLogo, si as SpRadioButtonText, vi as SpTextField, gi as SpTextFieldErrorText, bi as SpTextFieldUnit, yr as formDialogSizes, ir as iconButtonSizes, rr as iconButtonVariants, Sr as informationDialogSizes, li as snackbarSizes };

--- a/dist/mock.js
+++ b/dist/mock.js
@@ -4,6 +4,18 @@
   if (!customElements.get("sp-avatar")) {
     customElements.define("sp-avatar", class extends HTMLElement {});
   }
+  if (!customElements.get("mi-checkbox-text")) {
+    customElements.define("mi-checkbox-text", class extends HTMLElement {});
+  }
+  if (!customElements.get("sp-checkbox-text")) {
+    customElements.define("sp-checkbox-text", class extends HTMLElement {});
+  }
+  if (!customElements.get("mi-checkbox")) {
+    customElements.define("mi-checkbox", class extends HTMLElement {});
+  }
+  if (!customElements.get("sp-checkbox")) {
+    customElements.define("sp-checkbox", class extends HTMLElement {});
+  }
   if (!customElements.get("mi-ai-button")) {
     customElements.define("mi-ai-button", class extends HTMLElement {
       constructor() {
@@ -47,17 +59,11 @@
       }
     });
   }
-  if (!customElements.get("mi-checkbox-text")) {
-    customElements.define("mi-checkbox-text", class extends HTMLElement {});
+  if (!customElements.get("mi-input-chip-group")) {
+    customElements.define("mi-input-chip-group", class extends HTMLElement {});
   }
-  if (!customElements.get("sp-checkbox-text")) {
-    customElements.define("sp-checkbox-text", class extends HTMLElement {});
-  }
-  if (!customElements.get("mi-checkbox")) {
-    customElements.define("mi-checkbox", class extends HTMLElement {});
-  }
-  if (!customElements.get("sp-checkbox")) {
-    customElements.define("sp-checkbox", class extends HTMLElement {});
+  if (!customElements.get("mi-input-chip")) {
+    customElements.define("mi-input-chip", class extends HTMLElement {});
   }
   if (!customElements.get("mi-action-dialog")) {
     customElements.define("mi-action-dialog", class extends HTMLElement {

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -23,6 +23,36 @@ tests/<kebab-case>/
 - **ストーリー**: `stories/` 配下の既存ストーリーを参照。[storybook-autodocs.md](./storybook-autodocs.md) で autodocs の利用ルールと、カスタムイベントがある場合の Storybook Actions 連携チェックを確認
 - **テスト**: `tests/` 配下の既存テストを参照
 
+## 実装方針
+
+コンポーネントの API は **HTML だけで組み立てられること** を優先する。
+JavaScript でしか設定できないプロパティは最小限に留める。
+
+### リストデータの表現
+
+リスト的なデータは、配列プロパティ（`type: Array`）ではなく **子要素（slot）で表現する**。
+
+```html
+<!-- ○ slot 方式 -->
+<mi-input-chip-group>
+  <mi-input-chip label="Apple"></mi-input-chip>
+  <mi-input-chip label="Banana"></mi-input-chip>
+</mi-input-chip-group>
+```
+
+```js
+// ✕ 配列プロパティ方式
+group.items = [
+  { id: "1", label: "Apple" },
+  { id: "2", label: "Banana" },
+];
+```
+
+理由：
+
+- HTML だけで組み立てられる（JS 不要）
+- Web 標準（`<select>` + `<option>` 等）と同じ設計思想
+
 ## チェック
 
 - 新コンポーネントは `src/index.ts` にエクスポートを追加する

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -131,7 +132,6 @@
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -197,7 +197,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -246,7 +245,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -376,7 +374,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -389,7 +386,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2649,7 +2645,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2703,7 +2700,6 @@
       "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -2771,7 +2767,6 @@
       "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.0",
         "@typescript-eslint/types": "8.60.0",
@@ -2921,7 +2916,6 @@
       "integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.60.0",
@@ -3300,7 +3294,6 @@
       "integrity": "sha512-OlTlJej7YN6VwV7zJJoNeaCsctF+JXpzpZ4oBHUbrQFfIq+0KW2f07rprCLh9N/zRIZ0v4Mchn1QDDmWMUhPKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.1.7",
         "@vitest/mocker": "4.1.7",
@@ -3690,7 +3683,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3774,6 +3766,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -4148,7 +4141,6 @@
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mdn-data": "2.27.1",
         "source-map-js": "^1.2.1"
@@ -4182,7 +4174,8 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/custom-elements-manifest": {
       "version": "1.0.0",
@@ -4339,7 +4332,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -4392,7 +4386,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -4447,7 +4440,6 @@
       "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -5840,7 +5832,6 @@
       "integrity": "sha512-fycuvZg/hkpozL00lm1pEJH5nN/lr9ZXd6mJI2HSN4+Bzc+LDNdEApJ6HFbPkdFNHLvOplIIuJvxkS4XUxqirw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -5930,6 +5921,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6478,7 +6470,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -6521,7 +6512,6 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -6553,7 +6543,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -6587,6 +6576,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6670,7 +6660,6 @@
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6681,7 +6670,6 @@
       "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6694,7 +6682,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -6809,7 +6798,6 @@
       "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.132.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -7100,7 +7088,6 @@
       "integrity": "sha512-V1Zd2e+gBFufqAQVZ1JR8KLqALsEZ3JYSBnWwQbKa6zCfWWanR6AFMyuOkLt2gZOgGp3h2Riuz88pGNVTQSG0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.2",
@@ -7587,7 +7574,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8190,7 +8176,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8360,7 +8345,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.4"
       },
@@ -8425,7 +8409,6 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8517,7 +8500,6 @@
       "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.7",
         "@vitest/mocker": "4.1.7",

--- a/src/components/chip/input-chip-group.styles.ts
+++ b/src/components/chip/input-chip-group.styles.ts
@@ -1,0 +1,21 @@
+import { css } from "lit";
+
+export const inputChipGroupStyles = css`
+  :host {
+    display: block;
+  }
+
+  .container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-items: flex-start;
+    align-content: flex-start;
+  }
+
+  .item {
+    flex: 0 1 auto;
+    max-width: 100%;
+    min-width: 0;
+  }
+`;

--- a/src/components/chip/input-chip.styles.ts
+++ b/src/components/chip/input-chip.styles.ts
@@ -1,0 +1,46 @@
+import { css } from "lit";
+
+export const inputChipStyles = css`
+  :host {
+    display: inline-block;
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    max-width: 100%;
+    padding-inline-start: var(--spacing-large, 12px);
+    padding-inline-end: var(--spacing-small, 4px);
+    padding-block: 2px;
+    min-block-size: 28px;
+    border-radius: 9999px;
+    background-color: #e8edff;
+    box-sizing: border-box;
+  }
+
+  .label {
+    font-size: 12px;
+    font-weight: normal;
+    line-height: 1.5;
+    letter-spacing: 0.12px;
+    color: var(--text-regular-default, rgba(0, 0, 0, 0.84));
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+
+  @media (max-width: 720px) {
+    .chip {
+      min-block-size: 32px;
+    }
+
+    .label {
+      font-size: var(--font-scale-40, 14px);
+      letter-spacing: 0.14px;
+    }
+  }
+`;

--- a/src/components/chip/mi-input-chip-group.ts
+++ b/src/components/chip/mi-input-chip-group.ts
@@ -1,15 +1,7 @@
-import "./mi-input-chip";
-
 import { html, LitElement } from "lit";
-import { property } from "lit/decorators.js";
 
 import { makeStyles } from "../styles";
 import { inputChipGroupStyles } from "./input-chip-group.styles";
-
-export interface InputChipItem {
-  id: string;
-  label: string;
-}
 
 /**
  * @summary 複数の mi-input-chip をまとめて表示するグループコンポーネントです。
@@ -17,45 +9,23 @@ export interface InputChipItem {
  *
  * @example
  * ```html
- * <mi-input-chip-group
- *   aria-label="選択された項目"
- * ></mi-input-chip-group>
+ * <mi-input-chip-group aria-label="選択された項目">
+ *   <mi-input-chip label="Apple"></mi-input-chip>
+ *   <mi-input-chip label="Banana"></mi-input-chip>
+ * </mi-input-chip-group>
  * ```
  *
- * @fires remove - Chip の削除ボタンがクリックされたときに発火します。detail に削除対象の id を含みます。
+ * @slot - mi-input-chip 要素を配置します。
  */
 export class MiInputChipGroup extends LitElement {
   static override styles = makeStyles(inputChipGroupStyles);
 
-  /** 表示する Chip アイテムの配列。 */
-  @property({ type: Array })
-  items: InputChipItem[] = [];
-
   override render() {
     return html`
       <div class="container" role="list">
-        ${this.items.map(
-          (item) => html`
-            <div class="item" role="listitem">
-              <mi-input-chip
-                label=${item.label}
-                @remove=${() => this.handleRemove(item.id)}
-              ></mi-input-chip>
-            </div>
-          `,
-        )}
+        <slot></slot>
       </div>
     `;
-  }
-
-  private handleRemove(id: string) {
-    this.dispatchEvent(
-      new CustomEvent("remove", {
-        bubbles: false,
-        composed: false,
-        detail: { id },
-      }),
-    );
   }
 }
 

--- a/src/components/chip/mi-input-chip-group.ts
+++ b/src/components/chip/mi-input-chip-group.ts
@@ -1,0 +1,70 @@
+import "./mi-input-chip";
+
+import { html, LitElement } from "lit";
+import { property } from "lit/decorators.js";
+
+import { makeStyles } from "../styles";
+import { inputChipGroupStyles } from "./input-chip-group.styles";
+
+export interface InputChipItem {
+  id: string;
+  label: string;
+}
+
+/**
+ * @summary 複数の mi-input-chip をまとめて表示するグループコンポーネントです。
+ * ユーザーが入力した内容を要素ごとに整理して表示し、個別に削除できます。
+ *
+ * @example
+ * ```html
+ * <mi-input-chip-group
+ *   aria-label="選択された項目"
+ * ></mi-input-chip-group>
+ * ```
+ *
+ * @fires remove - Chip の削除ボタンがクリックされたときに発火します。detail に削除対象の id を含みます。
+ */
+export class MiInputChipGroup extends LitElement {
+  static override styles = makeStyles(inputChipGroupStyles);
+
+  /** 表示する Chip アイテムの配列。 */
+  @property({ type: Array })
+  items: InputChipItem[] = [];
+
+  override render() {
+    return html`
+      <div class="container" role="list">
+        ${this.items.map(
+          (item) => html`
+            <div class="item" role="listitem">
+              <mi-input-chip
+                label=${item.label}
+                @remove=${() => this.handleRemove(item.id)}
+              ></mi-input-chip>
+            </div>
+          `,
+        )}
+      </div>
+    `;
+  }
+
+  private handleRemove(id: string) {
+    this.dispatchEvent(
+      new CustomEvent("remove", {
+        bubbles: false,
+        composed: false,
+        detail: { id },
+      }),
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "mi-input-chip-group": MiInputChipGroup;
+  }
+}
+
+if (!customElements.get("mi-input-chip-group")) {
+  customElements.define("mi-input-chip-group", MiInputChipGroup);
+}

--- a/src/components/chip/mi-input-chip.ts
+++ b/src/components/chip/mi-input-chip.ts
@@ -1,0 +1,58 @@
+import "../button/mi-icon-button";
+
+import { html, LitElement } from "lit";
+import { property } from "lit/decorators.js";
+
+import { makeStyles } from "../styles";
+import { inputChipStyles } from "./input-chip.styles";
+
+/**
+ * @summary ユーザーが入力した内容を要素ごとに整理して表示するための Chip コンポーネントです。
+ * 企業やユーザーアカウントの入力などで利用され、×ボタンで入力内容を削除できます。
+ *
+ * @example
+ * ```html
+ * <mi-input-chip label="Apple"></mi-input-chip>
+ * ```
+ *
+ * @fires remove - 削除ボタンがクリックされたときに発火します。
+ */
+export class MiInputChip extends LitElement {
+  static override styles = makeStyles(inputChipStyles);
+
+  /** Chip に表示するテキスト。 */
+  @property({ type: String })
+  label = "";
+
+  override render() {
+    return html`
+      <span class="chip">
+        <span class="label">${this.label}</span>
+        <mi-icon-button
+          variant="ghost"
+          size="small"
+          icon-type="cross-small"
+          aria-label="${this.label}を削除"
+          tooltip-disabled
+          @click="${this.handleRemove}"
+        ></mi-icon-button>
+      </span>
+    `;
+  }
+
+  private handleRemove() {
+    this.dispatchEvent(
+      new CustomEvent("remove", { bubbles: false, composed: false }),
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "mi-input-chip": MiInputChip;
+  }
+}
+
+if (!customElements.get("mi-input-chip")) {
+  customElements.define("mi-input-chip", MiInputChip);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,11 @@ export {
   MiCheckboxText,
   SpCheckboxText,
 } from "./components/checkbox/mi-checkbox-text";
+export { MiInputChip } from "./components/chip/mi-input-chip";
+export {
+  type InputChipItem,
+  MiInputChipGroup,
+} from "./components/chip/mi-input-chip-group";
 export {
   type FormDialogSize,
   formDialogSizes,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,10 +17,7 @@ export {
   SpCheckboxText,
 } from "./components/checkbox/mi-checkbox-text";
 export { MiInputChip } from "./components/chip/mi-input-chip";
-export {
-  type InputChipItem,
-  MiInputChipGroup,
-} from "./components/chip/mi-input-chip-group";
+export { MiInputChipGroup } from "./components/chip/mi-input-chip-group";
 export {
   type FormDialogSize,
   formDialogSizes,

--- a/stories/chip/mi-input-chip-group.story.ts
+++ b/stories/chip/mi-input-chip-group.story.ts
@@ -1,0 +1,102 @@
+import "../../src/components/chip/mi-input-chip-group";
+
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+import { html } from "lit";
+import { action } from "storybook/actions";
+
+import type { MiInputChipGroup } from "../../src/components/chip/mi-input-chip-group";
+
+const sampleItems = [
+  { id: "1", label: "Apple" },
+  { id: "2", label: "Banana" },
+  { id: "3", label: "Cherry" },
+  { id: "4", label: "Dragon Fruit" },
+  { id: "5", label: "Elderberry" },
+];
+
+const meta = {
+  component: "mi-input-chip-group",
+  title: "Chip/mi-input-chip-group",
+  parameters: {
+    docs: {
+      description: {
+        component: [
+          "複数の mi-input-chip をまとめて表示するグループコンポーネントです。",
+          "ユーザーが入力した内容を要素ごとに整理して表示し、個別に削除できます。",
+        ].join("\n"),
+      },
+    },
+  },
+  argTypes: {
+    items: { control: "object" },
+    onRemove: {
+      name: "remove",
+      action: "remove",
+      description: "Chip の削除ボタンがクリックされたとき",
+      table: { category: "Events" },
+    },
+  },
+  args: {
+    items: sampleItems,
+    onRemove: action("remove"),
+  },
+  render: (args) => html`
+    <div style="padding: 40px;">
+      <mi-input-chip-group
+        .items=${args.items}
+        aria-label="選択された項目"
+        @remove=${args.onRemove}
+      ></mi-input-chip-group>
+    </div>
+  `,
+} satisfies Meta<MiInputChipGroup & { onRemove: () => void }>;
+
+export default meta;
+type Story = StoryObj<MiInputChipGroup>;
+
+export const Basic: Story = {
+  tags: ["!dev-only"],
+};
+
+export const Wrap: Story = {
+  render: () => html`
+    <div style="padding: 40px; max-width: 300px;">
+      <mi-input-chip-group
+        .items=${sampleItems}
+        aria-label="選択された項目"
+        @remove=${action("remove")}
+      ></mi-input-chip-group>
+    </div>
+  `,
+  parameters: {
+    docs: {
+      description: {
+        story: "幅が狭い場合、Chip が折り返して表示されます。",
+      },
+    },
+  },
+  tags: ["!dev-only"],
+};
+
+export const LongLabel: Story = {
+  render: () => html`
+    <div style="padding: 40px; max-width: 200px;">
+      <mi-input-chip-group
+        .items=${[
+          { id: "1", label: "とても長いラベルテキストが省略される例" },
+          { id: "2", label: "短いラベル" },
+        ]}
+        aria-label="選択された項目"
+        @remove=${action("remove")}
+      ></mi-input-chip-group>
+    </div>
+  `,
+  parameters: {
+    docs: {
+      description: {
+        story: "ラベルが長い場合、テキストが省略（ellipsis）されます。",
+      },
+    },
+  },
+  tags: ["!dev-only"],
+};

--- a/stories/chip/mi-input-chip-group.story.ts
+++ b/stories/chip/mi-input-chip-group.story.ts
@@ -1,18 +1,10 @@
+import "../../src/components/chip/mi-input-chip";
 import "../../src/components/chip/mi-input-chip-group";
 
 import type { Meta, StoryObj } from "@storybook/web-components-vite";
 import { html } from "lit";
-import { action } from "storybook/actions";
 
 import type { MiInputChipGroup } from "../../src/components/chip/mi-input-chip-group";
-
-const sampleItems = [
-  { id: "1", label: "Apple" },
-  { id: "2", label: "Banana" },
-  { id: "3", label: "Cherry" },
-  { id: "4", label: "Dragon Fruit" },
-  { id: "5", label: "Elderberry" },
-];
 
 const meta = {
   component: "mi-input-chip-group",
@@ -27,45 +19,36 @@ const meta = {
       },
     },
   },
-  argTypes: {
-    items: { control: "object" },
-    onRemove: {
-      name: "remove",
-      action: "remove",
-      description: "Chip の削除ボタンがクリックされたとき",
-      table: { category: "Events" },
-    },
-  },
-  args: {
-    items: sampleItems,
-    onRemove: action("remove"),
-  },
-  render: (args) => html`
-    <div style="padding: 40px;">
-      <mi-input-chip-group
-        .items=${args.items}
-        aria-label="選択された項目"
-        @remove=${args.onRemove}
-      ></mi-input-chip-group>
-    </div>
-  `,
-} satisfies Meta<MiInputChipGroup & { onRemove: () => void }>;
+} satisfies Meta<MiInputChipGroup>;
 
 export default meta;
 type Story = StoryObj<MiInputChipGroup>;
 
 export const Basic: Story = {
+  render: () => html`
+    <div style="padding: 40px;">
+      <mi-input-chip-group aria-label="選択された項目">
+        <mi-input-chip label="Apple"></mi-input-chip>
+        <mi-input-chip label="Banana"></mi-input-chip>
+        <mi-input-chip label="Cherry"></mi-input-chip>
+        <mi-input-chip label="Dragon Fruit"></mi-input-chip>
+        <mi-input-chip label="Elderberry"></mi-input-chip>
+      </mi-input-chip-group>
+    </div>
+  `,
   tags: ["!dev-only"],
 };
 
 export const Wrap: Story = {
   render: () => html`
     <div style="padding: 40px; max-width: 300px;">
-      <mi-input-chip-group
-        .items=${sampleItems}
-        aria-label="選択された項目"
-        @remove=${action("remove")}
-      ></mi-input-chip-group>
+      <mi-input-chip-group aria-label="選択された項目">
+        <mi-input-chip label="Apple"></mi-input-chip>
+        <mi-input-chip label="Banana"></mi-input-chip>
+        <mi-input-chip label="Cherry"></mi-input-chip>
+        <mi-input-chip label="Dragon Fruit"></mi-input-chip>
+        <mi-input-chip label="Elderberry"></mi-input-chip>
+      </mi-input-chip-group>
     </div>
   `,
   parameters: {
@@ -81,14 +64,12 @@ export const Wrap: Story = {
 export const LongLabel: Story = {
   render: () => html`
     <div style="padding: 40px; max-width: 200px;">
-      <mi-input-chip-group
-        .items=${[
-          { id: "1", label: "とても長いラベルテキストが省略される例" },
-          { id: "2", label: "短いラベル" },
-        ]}
-        aria-label="選択された項目"
-        @remove=${action("remove")}
-      ></mi-input-chip-group>
+      <mi-input-chip-group aria-label="選択された項目">
+        <mi-input-chip
+          label="とても長いラベルテキストが省略される例"
+        ></mi-input-chip>
+        <mi-input-chip label="短いラベル"></mi-input-chip>
+      </mi-input-chip-group>
     </div>
   `,
   parameters: {

--- a/stories/chip/mi-input-chip.story.ts
+++ b/stories/chip/mi-input-chip.story.ts
@@ -1,0 +1,57 @@
+import "../../src/components/chip/mi-input-chip";
+
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+import { html } from "lit";
+import { action } from "storybook/actions";
+
+import type { MiInputChip } from "../../src/components/chip/mi-input-chip";
+
+const meta = {
+  component: "mi-input-chip",
+  title: "Chip/mi-input-chip",
+  parameters: {
+    docs: {
+      description: {
+        component: [
+          "ユーザーが入力した内容を要素ごとに整理して表示するための Chip コンポーネントです。",
+          "企業やユーザーアカウントの入力などで利用され、×ボタンで入力内容を削除できます。",
+          "",
+          "> **Note:** React 版（mitsubachi-ui-react）には `disabled` プロパティがありますが、",
+          "> 現在の Figma デザインには disabled バリアントが定義されていないため、本コンポーネントでは未実装です。",
+          "> Figma に disabled が追加された際に対応予定です。",
+        ].join("\n"),
+      },
+    },
+  },
+  argTypes: {
+    label: { type: "string" },
+    onRemove: {
+      name: "remove",
+      action: "remove",
+      description: "削除ボタンがクリックされたとき",
+      table: { category: "Events" },
+    },
+  },
+  args: {
+    label: "Label",
+    onRemove: action("remove"),
+  },
+  render: (args) => html`
+    <div style="padding: 40px; display: inline-block;">
+      <mi-input-chip
+        label=${args.label}
+        @remove=${args.onRemove}
+      ></mi-input-chip>
+    </div>
+  `,
+} satisfies Meta<MiInputChip & { onRemove: () => void }>;
+
+export default meta;
+type Story = StoryObj<MiInputChip>;
+
+export const Basic: Story = {
+  args: {
+    label: "Apple",
+  },
+  tags: ["!dev-only"],
+};

--- a/tests/chip/mi-input-chip-group.test.ts
+++ b/tests/chip/mi-input-chip-group.test.ts
@@ -1,6 +1,6 @@
 import "../../src/components/chip/mi-input-chip-group";
 
-import { describe, expect, test, vi } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import type { MiInputChipGroup } from "../../src/components/chip/mi-input-chip-group";
 
@@ -12,160 +12,40 @@ function getContainer() {
   return getMiInputChipGroup().shadowRoot?.querySelector(".container");
 }
 
-function getItems() {
-  return getMiInputChipGroup().shadowRoot?.querySelectorAll(".item") ?? [];
-}
-
-function getChips() {
-  return (
-    getMiInputChipGroup().shadowRoot?.querySelectorAll("mi-input-chip") ?? []
-  );
-}
-
 describe("mi-input-chip-group", () => {
-  describe("items属性", () => {
-    test("items属性を設定すると、Chipが表示される", async () => {
-      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
+  describe("slot", () => {
+    test("slotに渡したmi-input-chipが表示される", async () => {
+      document.body.innerHTML = `
+        <mi-input-chip-group>
+          <mi-input-chip label="Apple"></mi-input-chip>
+          <mi-input-chip label="Banana"></mi-input-chip>
+        </mi-input-chip-group>
+      `;
       await customElements.whenDefined("mi-input-chip-group");
 
       const el = getMiInputChipGroup();
-      el.items = [
-        { id: "1", label: "Apple" },
-        { id: "2", label: "Banana" },
-      ];
       await el.updateComplete;
 
-      expect(getChips().length).toBe(2);
-    });
-
-    test("各Chipに正しいlabelが設定される", async () => {
-      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
-      await customElements.whenDefined("mi-input-chip-group");
-
-      const el = getMiInputChipGroup();
-      el.items = [
-        { id: "1", label: "Apple" },
-        { id: "2", label: "Banana" },
-      ];
-      await el.updateComplete;
-
-      const chips = getChips();
-      expect(chips[0].getAttribute("label")).toBe("Apple");
-      expect(chips[1].getAttribute("label")).toBe("Banana");
-    });
-
-    test("items属性が空配列の場合、Chipが表示されない", async () => {
-      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
-      await customElements.whenDefined("mi-input-chip-group");
-
-      const el = getMiInputChipGroup();
-      el.items = [];
-      await el.updateComplete;
-
-      expect(getChips().length).toBe(0);
-    });
-
-    test("items属性を更新すると、Chipが更新される", async () => {
-      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
-      await customElements.whenDefined("mi-input-chip-group");
-
-      const el = getMiInputChipGroup();
-      el.items = [{ id: "1", label: "Apple" }];
-      await el.updateComplete;
-      expect(getChips().length).toBe(1);
-
-      el.items = [
-        { id: "1", label: "Apple" },
-        { id: "2", label: "Banana" },
-        { id: "3", label: "Cherry" },
-      ];
-      await el.updateComplete;
-      expect(getChips().length).toBe(3);
-    });
-  });
-
-  describe("removeイベント", () => {
-    test("Chipの削除ボタンをクリックすると、removeイベントが発火する", async () => {
-      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
-      await customElements.whenDefined("mi-input-chip-group");
-
-      const el = getMiInputChipGroup();
-      el.items = [
-        { id: "1", label: "Apple" },
-        { id: "2", label: "Banana" },
-      ];
-      await el.updateComplete;
-
-      const handler = vi.fn();
-      el.addEventListener("remove", handler);
-
-      const chips = getChips();
-      await customElements.whenDefined("mi-input-chip");
-      const iconButton = chips[1].shadowRoot?.querySelector("mi-icon-button");
-      await customElements.whenDefined("mi-icon-button");
-      const button =
-        iconButton?.shadowRoot?.querySelector<HTMLButtonElement>("button");
-      button?.click();
-
-      expect(handler).toHaveBeenCalledTimes(1);
-      expect((handler.mock.calls[0][0] as CustomEvent).detail.id).toBe("2");
-    });
-
-    test("removeイベントがbubbles: falseとcomposed: falseを持つ", async () => {
-      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
-      await customElements.whenDefined("mi-input-chip-group");
-
-      const el = getMiInputChipGroup();
-      el.items = [{ id: "1", label: "Apple" }];
-      await el.updateComplete;
-
-      let event: CustomEvent | null = null;
-      el.addEventListener("remove", (e) => {
-        event = e as CustomEvent;
-      });
-
-      const chips = getChips();
-      await customElements.whenDefined("mi-input-chip");
-      const iconButton = chips[0].shadowRoot?.querySelector("mi-icon-button");
-      await customElements.whenDefined("mi-icon-button");
-      const button =
-        iconButton?.shadowRoot?.querySelector<HTMLButtonElement>("button");
-      button?.click();
-
-      expect(event).toBeTruthy();
-      expect(event!.bubbles).toBe(false);
-      expect(event!.composed).toBe(false);
-      expect(event!.cancelable).toBe(false);
+      const slot = getContainer()?.querySelector("slot");
+      const slotted = slot?.assignedElements({ flatten: true }) ?? [];
+      const chips = slotted.filter((n) => n.tagName === "MI-INPUT-CHIP");
+      expect(chips.length).toBe(2);
     });
   });
 
   describe("アクセシビリティ", () => {
     test("コンテナにrole=listが設定される", async () => {
-      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
+      document.body.innerHTML = `
+        <mi-input-chip-group>
+          <mi-input-chip label="Apple"></mi-input-chip>
+        </mi-input-chip-group>
+      `;
       await customElements.whenDefined("mi-input-chip-group");
 
       const el = getMiInputChipGroup();
-      el.items = [{ id: "1", label: "Apple" }];
       await el.updateComplete;
 
       expect(getContainer()?.getAttribute("role")).toBe("list");
-    });
-
-    test("各アイテムにrole=listitemが設定される", async () => {
-      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
-      await customElements.whenDefined("mi-input-chip-group");
-
-      const el = getMiInputChipGroup();
-      el.items = [
-        { id: "1", label: "Apple" },
-        { id: "2", label: "Banana" },
-      ];
-      await el.updateComplete;
-
-      const items = getItems();
-      for (const item of items) {
-        expect(item.getAttribute("role")).toBe("listitem");
-      }
     });
   });
 

--- a/tests/chip/mi-input-chip-group.test.ts
+++ b/tests/chip/mi-input-chip-group.test.ts
@@ -1,0 +1,180 @@
+import "../../src/components/chip/mi-input-chip-group";
+
+import { describe, expect, test, vi } from "vitest";
+
+import type { MiInputChipGroup } from "../../src/components/chip/mi-input-chip-group";
+
+function getMiInputChipGroup() {
+  return document.querySelector("mi-input-chip-group") as MiInputChipGroup;
+}
+
+function getContainer() {
+  return getMiInputChipGroup().shadowRoot?.querySelector(".container");
+}
+
+function getItems() {
+  return getMiInputChipGroup().shadowRoot?.querySelectorAll(".item") ?? [];
+}
+
+function getChips() {
+  return (
+    getMiInputChipGroup().shadowRoot?.querySelectorAll("mi-input-chip") ?? []
+  );
+}
+
+describe("mi-input-chip-group", () => {
+  describe("items属性", () => {
+    test("items属性を設定すると、Chipが表示される", async () => {
+      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
+      await customElements.whenDefined("mi-input-chip-group");
+
+      const el = getMiInputChipGroup();
+      el.items = [
+        { id: "1", label: "Apple" },
+        { id: "2", label: "Banana" },
+      ];
+      await el.updateComplete;
+
+      expect(getChips().length).toBe(2);
+    });
+
+    test("各Chipに正しいlabelが設定される", async () => {
+      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
+      await customElements.whenDefined("mi-input-chip-group");
+
+      const el = getMiInputChipGroup();
+      el.items = [
+        { id: "1", label: "Apple" },
+        { id: "2", label: "Banana" },
+      ];
+      await el.updateComplete;
+
+      const chips = getChips();
+      expect(chips[0].getAttribute("label")).toBe("Apple");
+      expect(chips[1].getAttribute("label")).toBe("Banana");
+    });
+
+    test("items属性が空配列の場合、Chipが表示されない", async () => {
+      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
+      await customElements.whenDefined("mi-input-chip-group");
+
+      const el = getMiInputChipGroup();
+      el.items = [];
+      await el.updateComplete;
+
+      expect(getChips().length).toBe(0);
+    });
+
+    test("items属性を更新すると、Chipが更新される", async () => {
+      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
+      await customElements.whenDefined("mi-input-chip-group");
+
+      const el = getMiInputChipGroup();
+      el.items = [{ id: "1", label: "Apple" }];
+      await el.updateComplete;
+      expect(getChips().length).toBe(1);
+
+      el.items = [
+        { id: "1", label: "Apple" },
+        { id: "2", label: "Banana" },
+        { id: "3", label: "Cherry" },
+      ];
+      await el.updateComplete;
+      expect(getChips().length).toBe(3);
+    });
+  });
+
+  describe("removeイベント", () => {
+    test("Chipの削除ボタンをクリックすると、removeイベントが発火する", async () => {
+      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
+      await customElements.whenDefined("mi-input-chip-group");
+
+      const el = getMiInputChipGroup();
+      el.items = [
+        { id: "1", label: "Apple" },
+        { id: "2", label: "Banana" },
+      ];
+      await el.updateComplete;
+
+      const handler = vi.fn();
+      el.addEventListener("remove", handler);
+
+      const chips = getChips();
+      await customElements.whenDefined("mi-input-chip");
+      const iconButton = chips[1].shadowRoot?.querySelector("mi-icon-button");
+      await customElements.whenDefined("mi-icon-button");
+      const button =
+        iconButton?.shadowRoot?.querySelector<HTMLButtonElement>("button");
+      button?.click();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect((handler.mock.calls[0][0] as CustomEvent).detail.id).toBe("2");
+    });
+
+    test("removeイベントがbubbles: falseとcomposed: falseを持つ", async () => {
+      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
+      await customElements.whenDefined("mi-input-chip-group");
+
+      const el = getMiInputChipGroup();
+      el.items = [{ id: "1", label: "Apple" }];
+      await el.updateComplete;
+
+      let event: CustomEvent | null = null;
+      el.addEventListener("remove", (e) => {
+        event = e as CustomEvent;
+      });
+
+      const chips = getChips();
+      await customElements.whenDefined("mi-input-chip");
+      const iconButton = chips[0].shadowRoot?.querySelector("mi-icon-button");
+      await customElements.whenDefined("mi-icon-button");
+      const button =
+        iconButton?.shadowRoot?.querySelector<HTMLButtonElement>("button");
+      button?.click();
+
+      expect(event).toBeTruthy();
+      expect(event!.bubbles).toBe(false);
+      expect(event!.composed).toBe(false);
+      expect(event!.cancelable).toBe(false);
+    });
+  });
+
+  describe("アクセシビリティ", () => {
+    test("コンテナにrole=listが設定される", async () => {
+      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
+      await customElements.whenDefined("mi-input-chip-group");
+
+      const el = getMiInputChipGroup();
+      el.items = [{ id: "1", label: "Apple" }];
+      await el.updateComplete;
+
+      expect(getContainer()?.getAttribute("role")).toBe("list");
+    });
+
+    test("各アイテムにrole=listitemが設定される", async () => {
+      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
+      await customElements.whenDefined("mi-input-chip-group");
+
+      const el = getMiInputChipGroup();
+      el.items = [
+        { id: "1", label: "Apple" },
+        { id: "2", label: "Banana" },
+      ];
+      await el.updateComplete;
+
+      const items = getItems();
+      for (const item of items) {
+        expect(item.getAttribute("role")).toBe("listitem");
+      }
+    });
+  });
+
+  describe("構造", () => {
+    test("container要素が存在する", async () => {
+      document.body.innerHTML = `<mi-input-chip-group></mi-input-chip-group>`;
+      await customElements.whenDefined("mi-input-chip-group");
+
+      expect(getContainer()).toBeTruthy();
+    });
+  });
+});

--- a/tests/chip/mi-input-chip.test.ts
+++ b/tests/chip/mi-input-chip.test.ts
@@ -1,0 +1,129 @@
+import "../../src/components/chip/mi-input-chip";
+
+import { describe, expect, test, vi } from "vitest";
+
+import type { MiInputChip } from "../../src/components/chip/mi-input-chip";
+
+function getMiInputChip() {
+  return document.querySelector("mi-input-chip") as MiInputChip;
+}
+
+function getChip() {
+  return getMiInputChip().shadowRoot?.querySelector(".chip");
+}
+
+function getLabel() {
+  return getMiInputChip().shadowRoot?.querySelector(".label");
+}
+
+function getIconButton() {
+  return getMiInputChip().shadowRoot?.querySelector("mi-icon-button");
+}
+
+describe("mi-input-chip", () => {
+  describe("label属性", () => {
+    test("label属性を設定すると、テキストが表示される", async () => {
+      document.body.innerHTML = `<mi-input-chip label="Apple"></mi-input-chip>`;
+      await customElements.whenDefined("mi-input-chip");
+
+      expect(getLabel()?.textContent).toBe("Apple");
+    });
+
+    test("label属性を更新すると、テキストが更新される", async () => {
+      document.body.innerHTML = `<mi-input-chip label="Apple"></mi-input-chip>`;
+      await customElements.whenDefined("mi-input-chip");
+
+      const el = getMiInputChip();
+      el.label = "Banana";
+      await el.updateComplete;
+
+      expect(getLabel()?.textContent).toBe("Banana");
+    });
+
+    test("label属性を設定しない場合、空文字が表示される", async () => {
+      document.body.innerHTML = `<mi-input-chip></mi-input-chip>`;
+      await customElements.whenDefined("mi-input-chip");
+
+      expect(getLabel()?.textContent).toBe("");
+    });
+  });
+
+  describe("削除ボタン", () => {
+    test("mi-icon-buttonがレンダリングされる", async () => {
+      document.body.innerHTML = `<mi-input-chip label="Apple"></mi-input-chip>`;
+      await customElements.whenDefined("mi-input-chip");
+
+      const iconButton = getIconButton();
+      expect(iconButton).toBeTruthy();
+      expect(iconButton?.getAttribute("icon-type")).toBe("cross-small");
+      expect(iconButton?.getAttribute("size")).toBe("small");
+      expect(iconButton?.getAttribute("variant")).toBe("ghost");
+    });
+
+    test("削除ボタンのaria-labelが「{label}を削除」になる", async () => {
+      document.body.innerHTML = `<mi-input-chip label="Apple"></mi-input-chip>`;
+      await customElements.whenDefined("mi-input-chip");
+
+      expect(getIconButton()?.getAttribute("aria-label")).toBe("Appleを削除");
+    });
+
+    test("label属性を更新すると、削除ボタンのaria-labelも更新される", async () => {
+      document.body.innerHTML = `<mi-input-chip label="Apple"></mi-input-chip>`;
+      await customElements.whenDefined("mi-input-chip");
+
+      const el = getMiInputChip();
+      el.label = "Banana";
+      await el.updateComplete;
+
+      expect(getIconButton()?.getAttribute("aria-label")).toBe("Bananaを削除");
+    });
+  });
+
+  describe("removeイベント", () => {
+    test("削除ボタンをクリックすると、removeイベントが発火する", async () => {
+      document.body.innerHTML = `<mi-input-chip label="Apple"></mi-input-chip>`;
+      await customElements.whenDefined("mi-input-chip");
+
+      const handler = vi.fn();
+      getMiInputChip().addEventListener("remove", handler);
+
+      const iconButton = getIconButton();
+      await customElements.whenDefined("mi-icon-button");
+      const button =
+        iconButton?.shadowRoot?.querySelector<HTMLButtonElement>("button");
+      button?.click();
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    test("removeイベントがbubbles: falseとcomposed: falseを持つ", async () => {
+      document.body.innerHTML = `<mi-input-chip label="Apple"></mi-input-chip>`;
+      await customElements.whenDefined("mi-input-chip");
+
+      let event: CustomEvent | null = null;
+      getMiInputChip().addEventListener("remove", (e) => {
+        event = e as CustomEvent;
+      });
+
+      const iconButton = getIconButton();
+      await customElements.whenDefined("mi-icon-button");
+      const button =
+        iconButton?.shadowRoot?.querySelector<HTMLButtonElement>("button");
+      button?.click();
+
+      expect(event).toBeTruthy();
+      expect(event!.bubbles).toBe(false);
+      expect(event!.composed).toBe(false);
+      expect(event!.cancelable).toBe(false);
+    });
+  });
+
+  describe("構造", () => {
+    test("chip要素が存在する", async () => {
+      document.body.innerHTML = `<mi-input-chip label="Apple"></mi-input-chip>`;
+      await customElements.whenDefined("mi-input-chip");
+
+      expect(getChip()).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## 概要

ユーザーが入力した内容を要素ごとに整理して表示するための InputChip コンポーネント（`mi-input-chip` / `mi-input-chip-group`）を追加します。

## 変更内容

- `mi-input-chip`: 単体の Chip コンポーネント（ラベル表示 + 削除ボタン）
- `mi-input-chip-group`: 複数の Chip をまとめて表示するグループコンポーネント（`role="list"` によるアクセシビリティ対応）
- Storybook ストーリー（Basic / Wrap / LongLabel バリエーション）
- テスト（プロパティ描画、イベント発火・bubbles・composed・cancelable、アクセシビリティ）
- `src/index.ts` に export を追加
- `dist/` を更新

## チームへの相談事項
@oki07 

### カスタムイベント `remove` の妥当性

`docs/event-architecture.md` に「カスタムイベントは原則定義しない。どうしても必要な場合はチームで議論して判断する」とあります。

本コンポーネントでは `remove` カスタムイベントを定義しています。必要と判断した理由は以下の通りです:

1. `mi-input-chip-group` はデータ（`items`）を自分で持たず、利用者から渡される設計（利用者がデータの所有者）
2. ×ボタンが押されたとき、「どの chip を削除したいか」を利用者に伝え、利用者側で `items` を更新してもらう必要がある
3. ネイティブの `click` イベントだけでは以下の理由で不十分:
   - chip 全体のクリックと×ボタンのクリックの区別がつかない
   - group 内に複数の chip がある場合、どの chip の×が押されたか特定できない（`composedPath()` で辿れば可能だが、利用者にコンポーネントの内部構造の知識を強いる）
4. group が自分で `items` を書き換える方式は、利用者側のデータとの不整合や、削除前の確認・API呼び出しなどの制御ができなくなる問題がある
5. 「chip の削除を要求する」に対応するネイティブ HTML イベントは存在しない
6. イベント名 `remove` はネイティブ HTML の命名規則（小文字、プレフィックスなし）に沿っている

**確認したいこと:**
- カスタムイベント `remove` を定義する方針で問題ないか
- イベント名 `remove` で適切か（別の名前の方がよいか）

## 変更の影響

- 見た目の変更:
- レビュワーに確認してほしいこと：

## 参考リンク

- Notion：
- Figma：[InputChip](https://www.figma.com/design/kHQNLM1dnk0EhZwOKBEBkL/Base-Component-Speeda-3.1-MITSUBACHI?node-id=6511-1849&t=IPoSrUSWfUik4zUA-1)