### PR TITLE
chore: package.json のバージョンを 2.14.0 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uzabase/mitsubachi-ui",
-  "version": "2.12.0",
+  "version": "2.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uzabase/mitsubachi-ui",
-      "version": "2.12.0",
+      "version": "2.13.1",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uzabase/mitsubachi-ui",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uzabase/mitsubachi-ui",
-      "version": "2.13.1",
+      "version": "2.14.0",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uzabase/mitsubachi-ui",
-  "version": "2.13.1",
+  "version": "2.14.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uzabase/mitsubachi-ui",
-  "version": "3.0.0",
+  "version": "2.13.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uzabase/mitsubachi-ui",
-  "version": "2.12.0",
+  "version": "3.0.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uzabase/mitsubachi-ui",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- タグ `3.0.0` は既に存在するが、`package.json` の version が `2.12.0` のままだったため `3.0.0` に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)