### PR TITLE
fix(button): variant の typo を plane → plain に修正（後方互換あり）

### DIFF
--- a/src/components/button/base.ts
+++ b/src/components/button/base.ts
@@ -16,17 +16,31 @@ export const variants = [
   "secondary",
   "tertiary",
   "ghost",
-  "plane",
+  "plain",
 ] as const;
 export type Variant = (typeof variants)[number];
+
+/** @deprecated `"plane"` は `"plain"` のタイポです。後方互換のため受け付けますが、新規利用では `"plain"` を使用してください。 */
+export type VariantCompat = Variant | "plane";
 
 export const sizes = ["medium", "large", "xLarge"] as const;
 export type Size = (typeof sizes)[number];
 
 export type ButtonTheme = "normal" | "danger" | "ai";
 
-export function isValidVariant(value: string): value is Variant {
-  return variants.some((variant) => variant === value);
+export function isValidVariant(value: string): value is Variant | "plane" {
+  return value === "plane" || variants.some((variant) => variant === value);
+}
+
+/** `"plane"` を `"plain"` に正規化する。それ以外はそのまま返す。 */
+export function normalizeVariant(value: Variant | "plane"): Variant {
+  if (value === "plane") {
+    console.warn(
+      'variant="plane" は非推奨です。代わりに variant="plain" を使用してください。',
+    );
+    return "plain";
+  }
+  return value;
 }
 
 export function isValidSize(value: string): value is Size {
@@ -83,7 +97,7 @@ export class ButtonBase<S extends string = Size> extends LitElement {
   toggle = false;
 
   @property({ type: String, reflect: true })
-  variant: Variant = "primary";
+  variant: VariantCompat = "primary";
 
   @property({ type: String, reflect: true })
   size: S = "medium" as S;
@@ -135,7 +149,7 @@ export class ButtonBase<S extends string = Size> extends LitElement {
     if (!validVariant) {
       console.warn(`${this.variant}は無効なvariant属性です。`);
     }
-    return validVariant ? this.variant : variants[0];
+    return validVariant ? normalizeVariant(this.variant) : variants[0];
   }
 
   protected get buttonClasses() {

--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -59,7 +59,7 @@ export const buttonStyles = css`
       }
     }
 
-    &.plane {
+    &.plain {
       --border-color: transparent;
       --background-color: transparent;
       --background-color-hover: rgb(49 92 232 / 8%);
@@ -181,7 +181,7 @@ export const buttonStyles = css`
     --color-disabled: rgb(0 0 0 / 35%);
   }
 
-  .plane {
+  .plain {
     --border-color-disabled: transparent;
     --background-color-disabled: transparent;
     --color-disabled: rgb(0 0 0 / 35%);

--- a/src/components/button/mi-neutral-button.ts
+++ b/src/components/button/mi-neutral-button.ts
@@ -4,9 +4,11 @@ import {
   ButtonBase,
   type ButtonTheme,
   isValidVariant,
+  normalizeVariant,
   type Size,
   sizes,
   type Variant,
+  type VariantCompat,
   variants,
 } from "./base";
 
@@ -27,10 +29,10 @@ export class MiNeutralButton extends ButtonBase {
    * @deprecated このプロパティは非推奨です。代わりに `variant` を使用してください。
    */
   @property({ type: String })
-  variants: Variant | null = null;
+  variants: VariantCompat | null = null;
 
   @property({ type: String })
-  override variant: Variant = "primary";
+  override variant: VariantCompat = "primary";
 
   protected override getTheme(): ButtonTheme {
     return this.danger ? "danger" : "normal";
@@ -42,11 +44,11 @@ export class MiNeutralButton extends ButtonBase {
     if (!validVariant) {
       console.warn(`${value}は無効なvariant属性です。`);
     }
-    return validVariant ? value : variants[0];
+    return validVariant ? normalizeVariant(value) : variants[0];
   }
 }
 
-export type { Size, Variant };
+export type { Size, Variant, VariantCompat };
 export { sizes, variants };
 
 /** @deprecated 代わりに MiNeutralButton を使用してください。後方互換のため別クラスとして登録しています。 */

--- a/tests/button/mi-button.test.ts
+++ b/tests/button/mi-button.test.ts
@@ -250,6 +250,23 @@ describe("mi-button", () => {
       expect(button?.classList.contains("primary")).toBe(true);
       expect(button?.classList.contains("invalid")).toBe(false);
     });
+
+    test('variant="plain"を設定すると、plainクラスが適用される', async () => {
+      document.body.innerHTML = `<mi-button variant="plain">ダウンロード</mi-button>`;
+      await customElements.whenDefined("mi-button");
+
+      const button = getButton();
+      expect(button?.classList.contains("plain")).toBe(true);
+    });
+
+    test('variant="plane"を設定すると、後方互換でplainクラスが適用される', async () => {
+      document.body.innerHTML = `<mi-button variant="plane">ダウンロード</mi-button>`;
+      await customElements.whenDefined("mi-button");
+
+      const button = getButton();
+      expect(button?.classList.contains("plain")).toBe(true);
+      expect(button?.classList.contains("plane")).toBe(false);
+    });
   });
 
   describe("size属性", () => {
@@ -489,6 +506,15 @@ describe("mi-button", () => {
 
       const button = getButton();
       expect(button?.classList.contains("tertiary")).toBe(true);
+    });
+
+    test('variants="plane"を設定すると、後方互換でplainクラスが適用される', async () => {
+      document.body.innerHTML = `<mi-button variants="plane">ダウンロード</mi-button>`;
+      await customElements.whenDefined("mi-button");
+
+      const button = getButton();
+      expect(button?.classList.contains("plain")).toBe(true);
+      expect(button?.classList.contains("plane")).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- `variant` の値 `"plane"` を正しい `"plain"` に修正
- 後方互換: `variant="plane"` は引き続き受け付け、内部で `"plain"` に正規化。deprecation 警告を console.warn で出力
- `VariantCompat` 型を追加し、TypeScript 型レベルでも後方互換を維持
- テスト追加: `variant="plain"` / `variant="plane"` / `variants="plane"` の正規化を検証

## Test plan
- [x] `npm run typecheck` パス
- [x] `npm run lint` パス
- [x] `npm run test` パス（69テスト全通過）
- [ ] Storybook で `plain` variant の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)