### PR TITLE
chore(deps): reset.css を git 依存から npm パッケージに変更

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 tag-version-prefix=""
+@uzabase:registry=https://registry.npmjs.org/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
-        "@sp-design/recet.css": "git+https://github.com/uzabase/sp-design-reset.css#semver:^1.0.2"
+        "@uzabase/reset.css": "^1.0.3"
       },
       "devDependencies": {
         "@custom-elements-manifest/analyzer": "^0.11.0",
@@ -2381,12 +2381,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@sp-design/recet.css": {
-      "name": "@sp-design/reset.css",
-      "version": "1.0.2",
-      "resolved": "git+ssh://git@github.com/uzabase/sp-design-reset.css.git#16f573a5d9b6c291e662a9de08ce2db668f10ec2",
-      "license": "MIT"
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -3264,6 +3258,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@uzabase/reset.css": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@uzabase/reset.css/-/reset.css-1.0.3.tgz",
+      "integrity": "sha512-yeKGjoihA5hMt1nMtZcBSjAQz3E7sZ8UJ2Tha8S76EQQwTVbH4w9ZwGeLQoajrocs076692KG6NkeaLovj6V8w==",
+      "license": "MIT"
     },
     "node_modules/@vitest/browser": {
       "version": "4.1.7",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "license": "MIT",
   "dependencies": {
     "@floating-ui/dom": "^1.7.6",
-    "@sp-design/recet.css": "git+https://github.com/uzabase/sp-design-reset.css#semver:^1.0.2"
+    "@uzabase/reset.css": "^1.0.3"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.11.0",

--- a/src/components/styles.ts
+++ b/src/components/styles.ts
@@ -1,4 +1,4 @@
-import resetStyle from "@sp-design/recet.css/src/reset.css?inline";
+import resetStyle from "@uzabase/reset.css?inline";
 import { css, type CSSResult, unsafeCSS } from "lit";
 
 import foundationStyle from "./foundation.css?inline";


### PR DESCRIPTION
## 概要

reset.css の依存を GitHub の git URL 直接参照から、npm に公開されている `@uzabase/reset.css` に切り替える。社内パッケージを npm registry 経由の取得に統一していく移行の一環。

## 変更内容

- `package.json` の依存を差し替え
  - 変更前: `"@sp-design/recet.css": "git+https://github.com/uzabase/sp-design-reset.css#semver:^1.0.2"`
  - 変更後: `"@uzabase/reset.css": "^1.0.3"`
  - パッケージ名の `recet` は `reset` のタイポだったため、これも解消される
- `src/components/styles.ts` の import を `@uzabase/reset.css?inline` に変更
  - サブパス（`/src/reset.css`）を指定しない形にしている。1.0.3 で `exports` フィールドが追加されたため、サブパス指定では解決できなくなるため
- `.npmrc` に `@uzabase:registry=https://registry.npmjs.org/` を追加
  - `@uzabase` スコープを GitHub Packages に向ける設定が個人の `~/.npmrc` に残っている環境では、npmjs 上の `@uzabase/reset.css` が 404 で取得できない。プロジェクト側で上書きして、開発者・CI のどちらでも解決できるようにする
- reset.css の内容自体は変更なし（見た目への影響なし）

## 変更の影響

- 見た目の変更: 無し


🤖 Generated with [Claude Code](https://claude.com/claude-code)