### PR TITLE
chore: package.json のバージョンを 2.15.0 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uzabase/mitsubachi-ui",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uzabase/mitsubachi-ui",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uzabase/mitsubachi-ui",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## 概要

mi-table コンポーネント群（#93）を含むリリースのため、バージョンを 2.15.0 に更新する。
マージ後に main へ 2.15.0 タグを作成し、npm に公開する。

## 変更内容

- `package.json` / `package-lock.json` のバージョンを 2.14.0 → 2.15.0 に更新
- `npm version minor --no-git-tag-version` で実行し、タグは作成していない
  - ブランチ上でタグを作ると、マージされないコミットを指す迷子タグになるため
  - タグはマージ後に main の先頭へ付ける

## 変更の影響

- 見た目の変更: 有り or 無し
- レビュワーに確認してほしいこと：有り or 無し

## 参考リンク

- Notion：（該当する場合にURLを記載）
- Figma：[変更したコンポーネント名](URL) // コンポーネントのFigma URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)