### PR TITLE
chore(ci): npmへ公開するGitHub Actionsワークフローを追加

### DIFF
--- a/.github/actions/prepare-release/action.yml
+++ b/.github/actions/prepare-release/action.yml
@@ -1,0 +1,115 @@
+name: Prepare release
+description: Scan, build, and create the file to publish to npm
+
+inputs:
+  version:
+    description: Version to publish
+    required: true
+
+outputs:
+  artifact-name:
+    description: Name of the temporary GitHub artifact
+    value: ${{ steps.package.outputs.artifact-name }}
+  package-file:
+    description: File to publish to npm
+    value: ${{ steps.package.outputs.package-file }}
+
+runs:
+  using: composite
+  steps:
+    - name: Betterleaksを準備
+      shell: bash
+      env:
+        BETTERLEAKS_SHA256: ea9ed6a4aa2845ac2e00c0eafbc841057631321d53c061d5a435cf33e6e9ddaf
+        BETTERLEAKS_VERSION: 1.7.2
+      run: |
+        set -euo pipefail
+        archive="betterleaks_${BETTERLEAKS_VERSION}_linux_x64.tar.gz"
+        archive_path="$RUNNER_TEMP/$archive"
+        install_dir="$RUNNER_TEMP/betterleaks"
+
+        curl --fail --location --proto '=https' --show-error --silent \
+          "https://github.com/betterleaks/betterleaks/releases/download/v${BETTERLEAKS_VERSION}/$archive" \
+          --output "$archive_path"
+        printf '%s  %s\n' "$BETTERLEAKS_SHA256" "$archive_path" | sha256sum --check -
+        mkdir -p "$install_dir"
+        tar -xzf "$archive_path" -C "$install_dir"
+        echo "$install_dir" >> "$GITHUB_PATH"
+
+    - name: ソースコードに秘密情報がないことを確認
+      shell: bash
+      run: |
+        set -euo pipefail
+        source_tree="$RUNNER_TEMP/source-tree"
+        mkdir -p "$source_tree"
+        git archive --format=tar "$GITHUB_SHA" | tar -xf - -C "$source_tree"
+        betterleaks dir "$source_tree" \
+          --no-banner \
+          --no-color \
+          --redact \
+          --timeout 120
+
+    - name: 公開バージョンを確認・反映
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        published_versions="$RUNNER_TEMP/published-versions.json"
+
+        npm view . versions --json > "$published_versions"
+        node tools/validate-release.mjs "$VERSION" "$published_versions"
+
+        npm version "$VERSION" \
+          --allow-same-version \
+          --ignore-scripts \
+          --no-git-tag-version
+
+    - name: 依存関係をインストール
+      shell: bash
+      run: npm ci
+
+    - name: 依存関係の署名と安全性を確認
+      shell: bash
+      run: |
+        npm audit signatures
+        # 公開するのはdistのみなので、利用者がインストールする本番依存だけを見る
+        npm audit --omit=dev --audit-level=high
+
+    - name: ビルド
+      shell: bash
+      run: npm run build
+
+    - name: npmへ公開するファイルを作成
+      id: package
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        release_dir="$RUNNER_TEMP/release"
+        packed_tree="$RUNNER_TEMP/packed-package"
+        manifest="$release_dir/pack.json"
+        metadata_dir="$release_dir/git-metadata"
+
+        mkdir -p "$release_dir" "$packed_tree" "$metadata_dir"
+        npm pack \
+          --ignore-scripts \
+          --json \
+          --pack-destination "$release_dir" > "$manifest"
+
+        package_file="$(node -e \
+          'const fs = require("fs"); console.log(JSON.parse(fs.readFileSync(process.argv[1], "utf8"))[0].filename)' \
+          "$manifest")"
+
+        tar -xzf "$release_dir/$package_file" -C "$packed_tree"
+        betterleaks dir "$packed_tree/package" \
+          --no-banner \
+          --no-color \
+          --redact \
+          --timeout 120
+
+        cp package.json package-lock.json "$metadata_dir/"
+
+        echo "artifact-name=package-$VERSION" >> "$GITHUB_OUTPUT"
+        echo "package-file=$package_file" >> "$GITHUB_OUTPUT"

--- a/.github/actions/tag-release/action.yml
+++ b/.github/actions/tag-release/action.yml
@@ -1,0 +1,57 @@
+name: Tag release
+description: Create an annotated tag on a release-only version commit
+
+inputs:
+  version:
+    description: Published version
+    required: true
+  release-directory:
+    description: Directory containing the release metadata
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: 同じGitタグがないか確認
+      id: existing-tag
+      shell: bash
+      env:
+        TAG: v${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+          echo "::notice::$TAG はすでにあるため、タグ作成をスキップします。"
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: タグ専用commitとGitタグを作成
+      if: steps.existing-tag.outputs.exists != 'true'
+      shell: bash
+      env:
+        RELEASE_DIR: ${{ inputs.release-directory }}
+        TAG: v${{ inputs.version }}
+      run: |
+        set -euo pipefail
+
+        cp \
+          "$RELEASE_DIR/git-metadata/package.json" \
+          "$RELEASE_DIR/git-metadata/package-lock.json" \
+          .
+
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add package.json package-lock.json
+        # mainのバージョンがすでに一致している場合は、mainのcommitへ直接タグを付ける
+        if ! git diff --cached --quiet; then
+          git commit -m "chore(release): $TAG"
+        fi
+
+        git tag --annotate "$TAG" --file=- <<EOF
+        $TAG をnpmへ公開しました
+
+        公開元commit: $GITHUB_SHA
+        EOF
+
+        git push origin "refs/tags/$TAG"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,144 @@
+name: Publish package to npm
+
+run-name: npmへ v${{ inputs.version }} を公開（@${{ github.actor }}）
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 公開するバージョン（例：1.2.3）
+        required: true
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: publish
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: 24.16.0
+
+jobs:
+  verify:
+    name: テストして公開ファイルを作成
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    outputs:
+      artifact-name: ${{ steps.prepare.outputs.artifact-name }}
+      package-file: ${{ steps.prepare.outputs.package-file }}
+    steps:
+      - name: ソースコードを取得
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.sha }}
+
+      - name: Node.jsを準備
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          package-manager-cache: false
+
+      - name: セキュリティ確認・公開ファイル作成
+        id: prepare
+        uses: ./.github/actions/prepare-release
+        with:
+          version: ${{ inputs.version }}
+
+      - name: 検査済みの公開ファイルを一時保存
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ steps.prepare.outputs.artifact-name }}
+          path: ${{ runner.temp }}/release/
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+      - name: 結果を表示
+        env:
+          PACKAGE_FILE: ${{ steps.prepare.outputs.package-file }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          {
+            echo "### npmへの公開準備が完了しました"
+            echo
+            echo "- バージョン: \`$VERSION\`"
+            echo "- npmへ公開するファイル: \`$PACKAGE_FILE\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: npmへ公開
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@uzabase/mitsubachi-ui/v/${{ inputs.version }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Node.jsを準備
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: 検査済みの公開ファイルを取得
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: ${{ needs.verify.outputs.artifact-name }}
+          path: ${{ runner.temp }}/release
+
+      - name: npmへ公開
+        env:
+          PACKAGE_FILE: ${{ needs.verify.outputs.package-file }}
+          RELEASE_DIR: ${{ runner.temp }}/release
+        run: |
+          npm publish "$RELEASE_DIR/$PACKAGE_FILE" \
+            --access public \
+            --ignore-scripts
+
+  tag:
+    name: 公開バージョンのGitタグを作成
+    needs:
+      - verify
+      - publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: 公開元のソースコードを取得
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+
+      - name: 公開したバージョン情報を取得
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: ${{ needs.verify.outputs.artifact-name }}
+          path: ${{ runner.temp }}/release
+
+      - name: タグ専用commitとGitタグを作成
+        uses: ./.github/actions/tag-release
+        with:
+          version: ${{ inputs.version }}
+          release-directory: ${{ runner.temp }}/release
+
+      - name: 結果を表示
+        env:
+          TAG: v${{ inputs.version }}
+        run: |
+          {
+            echo "### npmへの公開記録をGitへ保存しました"
+            echo
+            echo "- Gitタグ: \`$TAG\`"
+            echo "- 公開元commit: \`$GITHUB_SHA\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -114,4 +114,7 @@ fix(Tooltip): ホバー時の表示位置ずれを修正
 
 ### リリース
 
-- リリースは `npm run release:patch` / `npm run release:minor` / `npm run release:major`
+- GitHub Actions の [Publish package to npm](../.github/workflows/publish.yml) を main ブランチで手動実行する
+- 公開したいバージョンを `2.15.0` のような形式で入力する（npm 上の最新より新しい安定版のみ）
+- npm への公開が成功したあとに、そのバージョンの `package.json` を持つcommitへ `v2.15.0` の注釈付きタグが付く
+- main ブランチの `package.json` のバージョンは更新しない（npm が正本）

--- a/package.json
+++ b/package.json
@@ -27,9 +27,6 @@
     "fetch-icons": "tsx tools/fetch-icons.ts",
     "fetch-icon-colors": "tsx tools/fetch-icon-colors.ts",
     "fetch-logos": "tsx tools/fetch-logos.ts",
-    "release:patch": "npm version patch && git push && git push --tags",
-    "release:minor": "npm version minor && git push && git push --tags",
-    "release:major": "npm version major && git push && git push --tags",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },

--- a/tools/validate-release.mjs
+++ b/tools/validate-release.mjs
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+
+const STABLE_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+const fail = (message) => {
+  throw new Error(message);
+};
+
+const parseStableVersion = (version) => {
+  const match = STABLE_VERSION.exec(version);
+
+  if (!match) {
+    fail(`バージョンは 1.2.3 のように入力してください: ${version}`);
+  }
+
+  return match.slice(1).map(Number);
+};
+
+const compareVersions = (left, right) => {
+  const leftParts = parseStableVersion(left);
+  const rightParts = parseStableVersion(right);
+
+  for (let index = 0; index < leftParts.length; index += 1) {
+    if (leftParts[index] > rightParts[index]) return 1;
+    if (leftParts[index] < rightParts[index]) return -1;
+  }
+
+  return 0;
+};
+
+const [targetVersion, publishedVersionsPath] = process.argv.slice(2);
+
+parseStableVersion(targetVersion);
+
+const publishedVersions = JSON.parse(
+  readFileSync(publishedVersionsPath, "utf8"),
+);
+
+if (publishedVersions.includes(targetVersion)) {
+  fail(`${targetVersion} はすでにnpmへ公開されています`);
+}
+
+const latestVersion = publishedVersions
+  .filter((version) => STABLE_VERSION.test(version))
+  .reduce((latest, version) =>
+    compareVersions(version, latest) > 0 ? version : latest,
+  );
+
+// 古いバージョンを公開するとnpmのlatestタグが巻き戻ってしまう
+if (compareVersions(targetVersion, latestVersion) <= 0) {
+  fail(
+    `${targetVersion} はnpm上の最新安定版 ${latestVersion} より新しくありません`,
+  );
+}
+
+console.log(`公開バージョン: ${latestVersion} -> ${targetVersion}`);


### PR DESCRIPTION
- npm公開が成功したあとにGitタグを作成する手動実行のワークフローを追加

- 公開前にタグを打っていた release:* スクリプトを削除