### PR TITLE
chore: package.json のバージョンを 2.15.0 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uzabase/mitsubachi-ui",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uzabase/mitsubachi-ui",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uzabase/mitsubachi-ui",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
## 概要

npm 未公開のまま溜まっている変更をまとめて公開するため、バージョンを 2.15.0 に更新する。
マージ後に main へ 2.15.0 タグを作成し、npm に公開する。

npm の最新は 2.12.0 で、それ以降の 7 件が未公開のまま。
2.13.0 / 2.14.0 はタグのみ存在し npm には公開されていないため、npm 上のバージョンは 2.12.0 → 2.15.0 と飛ぶ。

## 変更内容

- `package.json` / `package-lock.json` のバージョンを 2.14.0 → 2.15.0 に更新
- `npm version minor --no-git-tag-version` で実行し、タグは作成していない
  - ブランチ上でタグを作ると、マージされないコミットを指す迷子タグになるため
  - タグはマージ後に main の先頭へ付ける

### このリリースに含まれる変更（2.12.0 以降）

| PR | 内容 |
| --- | --- |
| #88 | V2.12.0 |
| #90 | mi-helper-text 追加・mi-text-field エラー表示刷新 |
| #91 | mi-menu-button コンポーネント追加 |
| #94 | package.json のバージョンを 2.14.0 に更新 |
| #95 | fix(button): variant の typo を plane → plain に修正（後方互換あり） |
| #93 | mi-table コンポーネント群を追加 |
| #96 | chore(deps): reset.css を git 依存から npm パッケージに変更 |
| #92 | mi-select-box コンポーネント追加 |

新規コンポーネント: `mi-helper-text` / `mi-menu-button` / `mi-table` 系 / `mi-select-box` / `mi-select-box-unit`

破壊的変更は含まないため minor バンプとする。

## 変更の影響

- 見た目の変更: 有り or 無し
- レビュワーに確認してほしいこと：有り or 無し

## 参考リンク

- Notion：（該当する場合にURLを記載）
- Figma：[変更したコンポーネント名](URL) // コンポーネントのFigma URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
