### PR TITLE
feat: mi-text-area / mi-text-area-unit コンポーネントを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tests/**/__screenshots__
 *.log
 .vscode
 dist
+.vitest-attachments

--- a/src/components/label-unit/styles.css
+++ b/src/components/label-unit/styles.css
@@ -9,6 +9,9 @@
     gap: 8px;
     font-weight: var(--font-weight-bold);
     font-size: 14px;
+
+    /* line-height を明示しないと normal（フォント依存）になり、環境によって高さが変わる */
+    line-height: 1.5;
     color: #000000d6;
 
     &.none {
@@ -34,6 +37,9 @@
   .support {
     font-weight: var(--font-weight-normal);
     font-size: 12px;
+
+    /* 小さいサイズ向けの 130%（typography.md）。12px × 1.3 = 15.6px */
+    line-height: 1.3;
     color: #0000008a;
 
     &.none {

--- a/src/components/text-area/mi-text-area-unit.ts
+++ b/src/components/text-area/mi-text-area-unit.ts
@@ -1,0 +1,216 @@
+import "../label-unit";
+import "./mi-text-area";
+
+import { html, LitElement } from "lit";
+import { property } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
+
+import { makeStyles } from "../styles";
+import {
+  type MiTextArea,
+  normalizeRows,
+  type TextAreaSize,
+} from "./mi-text-area";
+import style from "./text-area-unit.styles";
+
+/**
+ * テキストエリアとラベルを組み合わせたコンポーネントです。
+ *
+ * ```html
+ * <mi-text-area-unit text="自己紹介" placeholder="入力してください" show-count max-length="100">
+ *   <span slot="error">入力内容に誤りがあります</span>
+ * </mi-text-area-unit>
+ * ```
+ *
+ * @summary テキストエリアを説明するラベル付きのテキストエリアです。
+ *
+ * @attr {string} text - テキストエリアを説明するテキストです。テキストエリアの上に表示されます。
+ *
+ * @attr {string} support-text - テキストエリアを補足するテキストです。text の下、テキストエリアの上に表示されます。
+ *
+ * @slot error - エラーメッセージ。要素ごとに1件のエラーとして表示されます。
+ *
+ * @fires change - 入力が確定したとき。ネイティブの `<textarea>` と同じく `bubbles: true` / `composed: false`。
+ *                 新しい値は `event.target.value` で取得する。
+ */
+export class MiTextAreaUnit extends LitElement {
+  static styles = makeStyles(style);
+
+  static formAssociated = true;
+
+  static shadowRootOptions = {
+    ...LitElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
+
+  /** ラベルテキスト */
+  @property({ type: String, reflect: true })
+  text = "";
+
+  /** ラベルに「必須」バッジを表示し、入力欄に `aria-required` を付与します。 */
+  @property({ type: Boolean, reflect: true })
+  required = false;
+
+  /**
+   * ラベルの下に表示する補足テキスト。
+   *
+   * 内側の `mi-text-area` の `description` にも渡し、`aria-describedby` 経由で
+   * スクリーンリーダーにも「この欄の説明」として伝わるようにしている。
+   */
+  @property({ type: String, attribute: "support-text", reflect: true })
+  supportText = "";
+
+  @property({ type: String, reflect: true })
+  value = "";
+
+  @property({ type: String, reflect: true })
+  placeholder = "";
+
+  @property({ type: String, reflect: true })
+  name = "";
+
+  @property({ type: Boolean, reflect: true })
+  disabled = false;
+
+  @property({ type: String, reflect: true })
+  size: TextAreaSize = "medium";
+
+  /** 入力エリアの最小の行数です。2 未満は 2 に正規化されます。 */
+  @property({ type: Number, attribute: "min-rows", reflect: true })
+  minRows = 2;
+
+  /**
+   * 入力エリアが自動で伸びる上限の行数です。未指定なら伸び続けます。
+   *
+   * `min-rows` と同じ値を指定すると高さが固定され、自動伸縮を止められます。
+   */
+  @property({ type: Number, attribute: "max-rows", reflect: true })
+  maxRows: number | null = null;
+
+  /** 文字数カウンターの上限値です。入力自体は制限しません。 */
+  @property({ type: Number, attribute: "max-length", reflect: true })
+  maxLength: number | null = null;
+
+  /** 文字数カウンターを表示します。 */
+  @property({ type: Boolean, attribute: "show-count", reflect: true })
+  showCount = false;
+
+  @property({ type: Boolean, reflect: true })
+  autofocus = false;
+
+  private internals: ElementInternals;
+
+  /**
+   * フォームのリセット時に戻す値。
+   *
+   * `value` は `reflect: true` で属性が入力に追従するため、属性から初期値を復元できない。
+   */
+  #initialValue = "";
+
+  constructor() {
+    super();
+    this.internals = this.attachInternals();
+  }
+
+  protected firstUpdated() {
+    this.#initialValue = this.value;
+  }
+
+  protected willUpdate() {
+    // 内側の mi-text-area も同じ正規化を行うが、こちらの公開プロパティ・属性も
+    // 揃えておかないと「属性は min-rows=1 なのに 2 行で表示される」食い違いが生まれる。
+    const rows = normalizeRows(this.minRows, this.maxRows);
+    this.minRows = rows.minRows;
+    this.maxRows = rows.maxRows;
+  }
+
+  /** `<form>` の reset で、ネイティブの `<textarea>` と同じく初期値に戻す。 */
+  formResetCallback() {
+    this.value = this.#initialValue;
+  }
+
+  protected updated(changedProperties: Map<string, unknown>) {
+    super.updated(changedProperties);
+
+    if (changedProperties.has("value")) {
+      this.internals.setFormValue(this.value);
+    }
+  }
+
+  /**
+   * 内側の mi-text-area の値を自身に同期する。
+   *
+   * `input` は `composed: true` で2段の Shadow DOM をそのまま越え、
+   * 境界で `target` がこの要素に付け替わるため、再発火はしない。
+   */
+  #handleInput(e: Event) {
+    this.value = (e.target as MiTextArea).value;
+  }
+
+  /**
+   * 内側の mi-text-area が発火する change を受け取り、自身の change として再発火する。
+   *
+   * `change` は `composed: false` なのでこのコンポーネントの境界も越えられない。
+   * 内部イベントは明示的に止めてから発火し直す（docs/event-architecture.md）。
+   */
+  #handleChange(e: Event) {
+    e.stopPropagation();
+    this.value = (e.target as MiTextArea).value;
+    this.dispatchEvent(new Event("change", { bubbles: true }));
+  }
+
+  #labelClasses() {
+    return classMap({
+      label: true,
+      // text が空でも support-text だけ表示したい場合があるため、両方空のときだけ隠す
+      none: !this.text && !this.supportText,
+    });
+  }
+
+  render() {
+    return html`
+      <fieldset>
+        <mi-label-unit
+          class="${this.#labelClasses()}"
+          text="${this.text}"
+          support-text="${this.supportText}"
+          ?required="${this.required}"
+        ></mi-label-unit>
+        <!--
+          name は内側に渡さない。フォーム値はこのコンポーネントが ElementInternals で
+          管理しており、内側の mi-text-area は Shadow DOM 内にあるため外側の <form> には
+          参加できない。両方に name を持たせても二重送信にはならないが、
+          どちらが送信主体か分かりにくくなるため意図的に渡していない。
+        -->
+        <mi-text-area
+          label="${this.text}"
+          description="${this.supportText}"
+          placeholder="${this.placeholder}"
+          size="${this.size}"
+          .minRows="${this.minRows}"
+          .maxRows="${this.maxRows}"
+          .maxLength="${this.maxLength}"
+          ?show-count="${this.showCount}"
+          ?required="${this.required}"
+          ?disabled="${this.disabled}"
+          ?autofocus="${this.autofocus}"
+          .value="${this.value}"
+          @input="${this.#handleInput}"
+          @change="${this.#handleChange}"
+        >
+          <slot name="error" slot="error"></slot>
+        </mi-text-area>
+      </fieldset>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "mi-text-area-unit": MiTextAreaUnit;
+  }
+}
+
+if (!customElements.get("mi-text-area-unit")) {
+  customElements.define("mi-text-area-unit", MiTextAreaUnit);
+}

--- a/src/components/text-area/mi-text-area.ts
+++ b/src/components/text-area/mi-text-area.ts
@@ -1,0 +1,475 @@
+import "../helper-text/mi-helper-text";
+
+import { html, LitElement, nothing } from "lit";
+import { property, state } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
+
+import { makeStyles } from "../styles";
+import style from "./text-area.styles";
+
+export const sizes = ["medium", "large"] as const;
+
+export type TextAreaSize = (typeof sizes)[number];
+
+/**
+ * 文字数をスクリーンリーダーに読み上げるまでの待ち時間（ミリ秒）。
+ *
+ * 入力のたびに読み上げるとキー入力を妨げるほど冗長になるため、入力が止まってから通知する。
+ * GOV.UK Design System は 500ms、SmartHR Design System は 1000ms を採用している。
+ */
+const SR_COUNT_ANNOUNCE_DELAY_MS = 1000;
+
+/**
+ * 文字数を数える。
+ *
+ * `String.length` は UTF-16 コード単位を数えるため、絵文字（😀）が2文字になってしまう。
+ * ユーザーの見た目に近づけるため、コードポイント単位で数える。
+ * SmartHR がサロゲートペアを引き算しているのと同じ結果になる。
+ *
+ * ただし ZWJ で連結された絵文字（👨‍👩‍👧‍👦 は7）や結合文字（か+濁点の「が」は2）は
+ * 見た目どおりにならない。完全に一致させるには `Intl.Segmenter`（書記素）が必要だが、
+ * 採用しているデザインシステムが無く、tsconfig の lib 変更も伴うため見送っている。
+ */
+const countCharacters = (value: string): number => [...value].length;
+
+/**
+ * 行数の指定を正規化する。mi-text-area / mi-text-area-unit の両方から使う。
+ *
+ * - 下限はデザイン仕様上 2 行。数値でない指定（`min-rows="abc"` 等）も 2 に寄せる
+ * - 上限が行数として意味を持たない場合（`max-rows`（値なし）は空文字 → 0 になる）は
+ *   「上限なし」として扱う。そのままだと上限 = 下限になり「一切伸びない」状態が
+ *   書き間違いで静かに作られてしまう
+ * - 上限は下限より小さくできない
+ */
+export const normalizeRows = (
+  minRows: number,
+  maxRows: number | null,
+): { minRows: number; maxRows: number | null } => {
+  const min = Math.max(2, Number.isFinite(minRows) ? minRows : 2);
+
+  if (maxRows == null || !Number.isFinite(maxRows) || maxRows <= 0) {
+    return { minRows: min, maxRows: null };
+  }
+  return { minRows: min, maxRows: Math.max(min, maxRows) };
+};
+
+/**
+ * @summary 複数行のテキストを入力・編集するテキストエリアです。1行の場合は `mi-text-field` を使用してください。
+ *
+ * @slot error - エラーメッセージ。要素ごとに1件のエラーとして表示されます。
+ *
+ * @fires change - 入力が確定したとき（ネイティブの `change` と同じタイミング）。
+ *                 ネイティブの `change` は `composed: false` で Shadow DOM を越えないため、ホスト要素から発火し直している。
+ *                 ネイティブの `<textarea>` と同じく `bubbles: true` / `composed: false`。
+ *                 新しい値は `event.target.value` で取得する。
+ */
+export class MiTextArea extends LitElement {
+  static styles = makeStyles(style);
+
+  static formAssociated = true;
+
+  static shadowRootOptions = {
+    ...LitElement.shadowRootOptions,
+    delegatesFocus: true,
+  };
+
+  @property({ type: String, reflect: true })
+  value = "";
+
+  @property({ type: String, reflect: true })
+  placeholder = "";
+
+  @property({ type: String, reflect: true })
+  name = "";
+
+  /**
+   * 入力欄の説明としてスクリーンリーダーに読み上げるテキスト。
+   *
+   * 視覚的には表示せず、`aria-describedby` から参照する。
+   * `mi-text-area-unit` が、画面に見えている補足テキスト（`mi-label-unit` が描画）と
+   * 同じ文言をここに渡すことで、見た目の関係を読み上げにも反映させている。
+   * 補足テキストは別の Shadow DOM 内にあり `aria-describedby` で直接参照できないため、
+   * 読み上げ用のテキストをこちら側に持つ形にしている。
+   */
+  @property({ type: String, reflect: true })
+  description = "";
+
+  /**
+   * 内部の `textarea` に設定する aria-label。
+   *
+   * Shadow DOM の外から `<label for>` や `aria-labelledby` で紐付けることはできないため、
+   * スクリーンリーダー向けの名前はこの属性で渡す。
+   */
+  @property({ type: String, reflect: true })
+  label = "";
+
+  @property({ type: Boolean, reflect: true })
+  disabled = false;
+
+  @property({ type: String, reflect: true })
+  size: TextAreaSize = "medium";
+
+  /**
+   * 入力エリアの最小の行数です。
+   *
+   * デザイン仕様上 2 行が下限のため、2 未満を指定した場合はプロパティ・属性ごと 2 に正規化されます。
+   */
+  @property({ type: Number, attribute: "min-rows", reflect: true })
+  minRows = 2;
+
+  /**
+   * 入力エリアが自動で伸びる上限の行数です。
+   *
+   * 未指定の場合は入力量に応じて伸び続けます。
+   * 指定するとその行数で止まり、以降はテキストエリア内がスクロールします。
+   *
+   * `min-rows` より小さい値を指定した場合は `min-rows` に正規化されます。
+   * そのため `min-rows` と同じ値を指定すると高さが固定され、自動伸縮を止められます
+   * （例: `min-rows="3" max-rows="3"` で常に3行分）。
+   */
+  @property({ type: Number, attribute: "max-rows", reflect: true })
+  maxRows: number | null = null;
+
+  /**
+   * 文字数カウンターの上限値です。
+   *
+   * ネイティブの `maxlength` と異なり入力自体は制限しません。
+   * 上限を超えた場合はカウンターの現在値を強調表示するのみで、送信可否の判断は利用側に委ねます。
+   *
+   * 文字数はコードポイント単位で数えるため、絵文字（😀）は1文字になります。
+   * ネイティブの `maxlength` は UTF-16 コード単位（😀 は2文字）なので、数え方が異なります。
+   *
+   * また、改行はこのカウンターでは1文字ですが、フォーム送信時には仕様上 `\r\n` に
+   * 正規化されるため、サーバーが受け取る文字数は改行の数だけ多くなります。
+   * 改行を多く含む用途で厳密な文字数制限が必要な場合は、利用側で考慮してください。
+   */
+  @property({ type: Number, attribute: "max-length", reflect: true })
+  maxLength: number | null = null;
+
+  /** 文字数カウンターを表示します。 */
+  @property({ type: Boolean, attribute: "show-count", reflect: true })
+  showCount = false;
+
+  /**
+   * 入力欄に `aria-required="true"` を付与します。
+   *
+   * ネイティブの `required` は付けないため、ブラウザによる送信時バリデーションは行いません
+   * （`max-length` をソフト制限としているのと同じ方針です）。
+   */
+  @property({ type: Boolean, reflect: true })
+  required = false;
+
+  @property({ type: Boolean, reflect: true })
+  autofocus = false;
+
+  @state()
+  private _slottedErrorHtml: string[] = [];
+
+  /** スクリーンリーダーへ読み上げる文字数メッセージ。入力が止まってから更新される。 */
+  @state()
+  private _srCountMessage = "";
+
+  private internals: ElementInternals;
+
+  #srCountTimerId?: number;
+
+  /**
+   * 現在の文字数。
+   *
+   * 1回の描画で何度も参照される（赤枠の判定・カウンター表示・aria-describedby）ため、
+   * 更新ごとに1回だけ数えて持っておく。
+   */
+  #characterCount = 0;
+
+  /**
+   * フォームのリセット時に戻す値。
+   *
+   * `value` は `reflect: true` で属性が入力に追従するため、属性から初期値を復元できない。
+   * そのため最初の描画時に控えておく（`mi-radio-button-text-group` と同じ方式）。
+   */
+  #initialValue = "";
+
+  constructor() {
+    super();
+    this.internals = this.attachInternals();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.#clearSrCountTimer();
+  }
+
+  protected firstUpdated() {
+    this.#initialValue = this.value;
+  }
+
+  protected willUpdate() {
+    this.#characterCount = countCharacters(this.value);
+
+    // 行数はここでプロパティ自体を正規化する。
+    // 描画時だけ補正すると「属性は min-rows=1 なのに 2 行で表示される」という
+    // 食い違いが生まれ、DOM を見ても実際の値が分からなくなるため。
+    const rows = normalizeRows(this.minRows, this.maxRows);
+    this.minRows = rows.minRows;
+    this.maxRows = rows.maxRows;
+  }
+
+  /** `<form>` の reset で、ネイティブの `<textarea>` と同じく初期値に戻す。 */
+  formResetCallback() {
+    this.value = this.#initialValue;
+  }
+
+  protected updated(changedProperties: Map<string, unknown>) {
+    super.updated(changedProperties);
+
+    if (changedProperties.has("value")) {
+      this.internals.setFormValue(this.value);
+    }
+  }
+
+  /** エラーの見た目（赤枠）にする状態か。文字数超過も含む。 */
+  get #hasError() {
+    return (
+      (!this.disabled && this._slottedErrorHtml.length > 0) ||
+      this.#showsOverMaxLength
+    );
+  }
+
+  /**
+   * 高さの計算に使う CSS カスタムプロパティ。
+   *
+   * 実際の calc はサイズごとの行の高さを知っている CSS 側で行う。
+   *
+   * `style` 属性を文字列でバインドすると、ユーザーが手動リサイズしたときに
+   * ブラウザが書き込んだ `height` を Lit が丸ごと上書きして消してしまう。
+   * `styleMap` は自分が管理するプロパティだけを操作するため、手動リサイズが残る。
+   */
+  get #heightStyles(): Record<string, string> {
+    const styles: Record<string, string> = {
+      "--text-area-min-rows": String(this.minRows),
+    };
+    if (this.maxRows != null) {
+      styles["--text-area-max-rows"] = String(this.maxRows);
+    }
+    return styles;
+  }
+
+  get #isOverMaxLength() {
+    return this.maxLength != null && this.#characterCount > this.maxLength;
+  }
+
+  /**
+   * 上限超過をユーザーに知らせる状態か。
+   *
+   * カウンターを出していないときに理由の分からない赤枠だけを見せないよう、`show-count` を条件に含める。
+   * disabled は入力自体ができないため対象外とする。
+   */
+  get #showsOverMaxLength() {
+    return this.showCount && !this.disabled && this.#isOverMaxLength;
+  }
+
+  /** スクリーンリーダー向けの文字数メッセージ。記号ではなく文章で伝える。 */
+  get #countMessage(): string {
+    if (this.maxLength == null) return `${this.#characterCount}文字`;
+
+    const remaining = this.maxLength - this.#characterCount;
+    return remaining < 0 ? `${-remaining}文字オーバー` : `あと${remaining}文字`;
+  }
+
+  #errorIdPrefix = "error";
+
+  #descriptionId = "description";
+
+  #countDescriptionId = "count-description";
+
+  get #errorIds(): string[] {
+    return this._slottedErrorHtml.map((_, i) => `${this.#errorIdPrefix}-${i}`);
+  }
+
+  get #hasCountDescription() {
+    return this.showCount && this.maxLength != null;
+  }
+
+  get #describedByIds(): string[] {
+    const ids: string[] = [];
+    if (this.description) ids.push(this.#descriptionId);
+    if (this.#hasCountDescription) ids.push(this.#countDescriptionId);
+    if (this.#hasError) ids.push(...this.#errorIds);
+    return ids;
+  }
+
+  #clearSrCountTimer() {
+    if (this.#srCountTimerId !== undefined) {
+      clearTimeout(this.#srCountTimerId);
+      this.#srCountTimerId = undefined;
+    }
+  }
+
+  #scheduleSrCountMessage() {
+    if (!this.showCount) return;
+
+    this.#clearSrCountTimer();
+    this.#srCountTimerId = window.setTimeout(() => {
+      this._srCountMessage = this.#countMessage;
+      this.#srCountTimerId = undefined;
+    }, SR_COUNT_ANNOUNCE_DELAY_MS);
+  }
+
+  #handleErrorSlotChange(e: Event) {
+    const slot = e.target as HTMLSlotElement;
+    // mi-text-area-unit のように <slot slot="error"> 経由で差し込まれる場合、
+    // flatten なしだと slot 要素そのものが返り、中身を取り出せない。
+    this._slottedErrorHtml = slot
+      .assignedElements({ flatten: true })
+      .map((el) => el.innerHTML)
+      .filter((h) => h.trim() !== "");
+  }
+
+  // ネイティブの input は composed: true のため、Shadow DOM の外までそのまま届く。
+  // ここでは value の同期だけを行い、再発火はしない。
+  #handleInput(e: Event) {
+    const target = e.target as HTMLTextAreaElement;
+    this.value = target.value;
+    this.#scheduleSrCountMessage();
+  }
+
+  /**
+   * ネイティブの `change` は `composed: false` で Shadow DOM を越えないため、ホスト要素から発火し直す。
+   *
+   * `bubbles` / `composed` は docs/event-architecture.md の「ネイティブ互換」に従い、
+   * ネイティブの `<textarea>` と同じ値（`bubbles: true` / `composed: false`）にする。
+   * `<form>` 側で `change` を拾う使い方をネイティブと同じようにできるようにするため。
+   * `mi-select-box` が `<select>` に合わせているのと同じ方針。
+   */
+  #handleChange(e: Event) {
+    this.dispatchEvent(
+      new Event("change", {
+        bubbles: true,
+        cancelable: e.cancelable,
+        composed: false,
+      }),
+    );
+  }
+
+  #textareaClasses() {
+    return classMap({
+      textarea: true,
+      error: this.#hasError,
+    });
+  }
+
+  #renderCount() {
+    if (!this.showCount) return nothing;
+
+    // 見た目のカウンター（例: 111/100）は記号が読み上げに向かないため隠し、
+    // 代わりにライブリージョンで「あと○文字」「○文字オーバー」と文章で通知する。
+    return html`
+      <div
+        class="${classMap({ count: true, disabled: this.disabled })}"
+        aria-hidden="true"
+      >
+        <span
+          class="${classMap({
+            "count-current": true,
+            over: this.#showsOverMaxLength,
+          })}"
+          >${this.#characterCount}</span
+        >
+        ${this.maxLength != null
+          ? html`<span>/</span> <span>${this.maxLength}</span>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  /** 入力欄の説明。視覚的には出さず aria-describedby から参照する。 */
+  #renderDescription() {
+    if (!this.description) return nothing;
+
+    return html`
+      <div id="${this.#descriptionId}" class="visually-hidden">
+        ${this.description}
+      </div>
+    `;
+  }
+
+  /** 入力前に上限を知らせる説明。aria-describedby から参照する。 */
+  #renderCountDescription() {
+    if (!this.#hasCountDescription) return nothing;
+
+    return html`
+      <div id="${this.#countDescriptionId}" class="visually-hidden">
+        最大${this.maxLength}文字入力できます
+      </div>
+    `;
+  }
+
+  /** 入力中の文字数変化を通知するライブリージョン。 */
+  #renderSrCount() {
+    if (!this.showCount) return nothing;
+
+    return html`
+      <div class="visually-hidden" role="status" aria-live="polite">
+        ${this._srCountMessage}
+      </div>
+    `;
+  }
+
+  #renderErrors() {
+    if (!this.#hasError) return nothing;
+
+    return this._slottedErrorHtml.map(
+      (content, i) => html`
+        <mi-helper-text
+          id="${this.#errorIdPrefix}-${i}"
+          status="error"
+          size="medium"
+          >${unsafeHTML(content)}</mi-helper-text
+        >
+      `,
+    );
+  }
+
+  render() {
+    return html`
+      <textarea
+        class="${this.#textareaClasses()}"
+        data-size="${this.size}"
+        placeholder="${this.placeholder}"
+        name="${this.name}"
+        rows="${this.minRows}"
+        style=${styleMap(this.#heightStyles)}
+        ?data-has-max-rows="${this.maxRows != null}"
+        ?disabled="${this.disabled}"
+        ?autofocus="${this.autofocus}"
+        aria-label="${this.label || nothing}"
+        aria-required="${this.required ? "true" : "false"}"
+        .value="${this.value}"
+        aria-invalid="${this.#hasError ? "true" : "false"}"
+        aria-describedby="${this.#describedByIds.join(" ")}"
+        @input="${this.#handleInput}"
+        @change="${this.#handleChange}"
+      ></textarea>
+      ${this.#renderCount()} ${this.#renderDescription()}
+      ${this.#renderCountDescription()} ${this.#renderSrCount()}
+      <slot
+        name="error"
+        @slotchange=${this.#handleErrorSlotChange}
+        hidden
+      ></slot>
+      ${this.#renderErrors()}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "mi-text-area": MiTextArea;
+  }
+}
+
+if (!customElements.get("mi-text-area")) {
+  customElements.define("mi-text-area", MiTextArea);
+}

--- a/src/components/text-area/text-area-unit.styles.ts
+++ b/src/components/text-area/text-area-unit.styles.ts
@@ -1,0 +1,20 @@
+import { css } from "lit";
+
+export default css`
+  :host {
+    display: block;
+
+    /* 内側の mi-text-area と同じ理由でコンテナ幅に追従させる */
+    inline-size: 100%;
+
+    .label {
+      /* Figma: label-unit とテキストエリアの間隔は 8px */
+      margin-block-end: 8px;
+      text-align: start;
+
+      &.none {
+        display: none;
+      }
+    }
+  }
+`;

--- a/src/components/text-area/text-area.styles.ts
+++ b/src/components/text-area/text-area.styles.ts
@@ -1,0 +1,166 @@
+import { css } from "lit";
+
+export default css`
+  :host {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+
+    /*
+     * field-sizing: content は幅の intrinsic size も内容ベースにするため、
+     * flex アイテムのように「内容に合わせて縮む」文脈では極端に細くなってしまう。
+     * 既定でコンテナ幅に追従させる（利用側の幅指定はこれより優先される）。
+     */
+    inline-size: 100%;
+  }
+
+  .textarea {
+    inline-size: 100%;
+    box-sizing: border-box;
+
+    /*
+     * 入力量に応じて高さが伸びる。下限・上限は min/max-block-size で挟む。
+     * 高さは「2行分の高さ（Figma 由来）＋ 超過分の行数 × 1行の高さ」で求める。
+     *
+     * field-sizing 未対応のブラウザではこの宣言が無視され、rows 属性による
+     * 固定高さ（= 最小行数）になる。自動伸縮が効かないだけで表示は壊れない。
+     */
+    field-sizing: content;
+    min-block-size: calc(
+      var(--text-area-rows-2-block-size) + (var(--text-area-min-rows, 2) - 2) *
+        var(--text-area-row-block-size)
+    );
+    background-color: var(--surface-regular-default, #fff);
+    border: 1px solid var(--border-semi-strong-default, rgb(0 0 0 / 20%));
+    border-radius: var(--radius-medium, 6px);
+    color: var(--text-regular-default, rgb(0 0 0 / 84%));
+    font-weight: var(--font-weight-normal);
+    line-height: 1.5;
+    resize: vertical;
+
+    &::placeholder {
+      color: var(--text-weak-default, rgb(0 0 0 / 54%));
+    }
+
+    &:hover:not(:disabled, :focus-visible) {
+      border-color: var(--border-semi-strong-hover, rgb(0 0 0 / 35%));
+    }
+
+    &:focus-visible {
+      outline: none;
+      box-shadow:
+        0 0 0 2px var(--surface-regular-default, #fff),
+        0 0 0 4px var(--focus-ring-default, #191919);
+    }
+
+    /* max-rows を指定したときだけ上限をかける（未指定なら伸び続ける） */
+    &[data-has-max-rows] {
+      max-block-size: calc(
+        var(--text-area-rows-2-block-size) + (var(--text-area-max-rows) - 2) *
+          var(--text-area-row-block-size)
+      );
+    }
+
+    &.error {
+      border-color: var(--border-error-default, #db351f);
+
+      &:hover:not(:disabled, :focus-visible) {
+        border-color: var(--border-error-hover, #b02412);
+      }
+    }
+
+    &:disabled {
+      background-color: var(--surface-regular-disabled, rgb(0 0 0 / 3%));
+      border-color: var(--border-disabled, rgb(0 0 0 / 7%));
+      color: var(--text-disabled, rgb(0 0 0 / 35%));
+      resize: none;
+
+      &::placeholder {
+        color: var(--text-disabled, rgb(0 0 0 / 35%));
+      }
+    }
+  }
+
+  .textarea[data-size="medium"] {
+    /* 58px = Figma の2行分。21px = font-size 14px × line-height 1.5 */
+    --text-area-rows-2-block-size: 58px;
+    --text-area-row-block-size: 21px;
+
+    padding-block: 8px;
+    padding-inline: 8px;
+    font-size: 14px;
+    letter-spacing: 0.28px;
+
+    &::placeholder {
+      letter-spacing: 0.14px;
+    }
+  }
+
+  .textarea[data-size="large"] {
+    /* 64px = Figma の2行分。24px = font-size 16px × line-height 1.5 */
+    --text-area-rows-2-block-size: 64px;
+    --text-area-row-block-size: 24px;
+
+    padding-block: 8px;
+    padding-inline: 12px;
+    font-size: 16px;
+    letter-spacing: 0.32px;
+
+    &::placeholder {
+      letter-spacing: 0.16px;
+    }
+  }
+
+  .count {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 2px;
+    color: var(--text-regular-default, rgb(0 0 0 / 84%));
+    font-size: 12px;
+    letter-spacing: 0.12px;
+    line-height: 1.5;
+    white-space: nowrap;
+  }
+
+  .count.disabled {
+    color: var(--text-disabled, rgb(0 0 0 / 35%));
+  }
+
+  .count-current.over {
+    color: var(--text-negative, #c92812);
+    font-weight: var(--font-weight-bold);
+  }
+
+  /* 視覚的には隠すが、スクリーンリーダーには読み上げさせる */
+  .visually-hidden {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  /* スマートフォン幅ではフォントを 16px にし（iOS の自動ズーム回避）、リサイズハンドルを出さない */
+  @media (width <= 720px) {
+    .textarea {
+      resize: none;
+    }
+
+    .textarea[data-size="medium"] {
+      --text-area-rows-2-block-size: 64px;
+      --text-area-row-block-size: 24px;
+
+      font-size: 16px;
+      letter-spacing: 0.32px;
+
+      &::placeholder {
+        letter-spacing: 0.16px;
+      }
+    }
+  }
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,9 @@ export {
   MiTableHeaderCell,
   MiTableRow,
 } from "./components/table";
+export type { TextAreaSize } from "./components/text-area/mi-text-area";
+export { MiTextArea } from "./components/text-area/mi-text-area";
+export { MiTextAreaUnit } from "./components/text-area/mi-text-area-unit";
 export { MiTextField, SpTextField } from "./components/text-field/text-field";
 export {
   MiTextFieldErrorText,

--- a/stories/text-area/mi-text-area-unit.story.ts
+++ b/stories/text-area/mi-text-area-unit.story.ts
@@ -1,0 +1,225 @@
+import "../../src/components/text-area/mi-text-area-unit";
+
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+import type { TemplateResult } from "lit";
+import { html, nothing } from "lit";
+import { action } from "storybook/actions";
+
+import { sizes } from "../../src/components/text-area/mi-text-area";
+import type { MiTextAreaUnit } from "../../src/components/text-area/mi-text-area-unit";
+
+/** Storybook Actions / Slots 用（コンポーネントの公開 API 外） */
+type MiTextAreaUnitStory = MiTextAreaUnit & {
+  onChange?: (...args: unknown[]) => void;
+  errorSlot: TemplateResult | typeof nothing;
+};
+
+const meta: Meta<MiTextAreaUnitStory> = {
+  component: "mi-text-area-unit",
+  title: "Components/TextArea/mi-text-area-unit",
+  args: {
+    text: "自己紹介",
+    supportText: "",
+    value: "",
+    placeholder: "テキストを入力してください",
+    size: "medium",
+    minRows: 2,
+    maxRows: null,
+    disabled: false,
+    required: false,
+    showCount: false,
+    maxLength: null,
+    name: "body",
+    onChange: action("change"),
+    errorSlot: "none" as unknown as TemplateResult,
+  },
+  argTypes: {
+    text: {
+      description:
+        "テキストエリアを説明するラベル。内側の `textarea` の `aria-label` にも渡されます",
+    },
+    supportText: {
+      description: "ラベルの下に表示する補足テキスト",
+    },
+    size: {
+      control: { type: "select" },
+      options: [...sizes],
+    },
+    minRows: {
+      control: { type: "number" },
+      description:
+        "入力エリアの最小の行数。2 未満を指定すると 2 に正規化されます",
+    },
+    maxRows: {
+      control: { type: "number" },
+      description:
+        "自動で伸びる上限の行数。未指定なら伸び続けます。指定するとその行数で止まり、以降はスクロールします。`min-rows` と同じ値にすると高さが固定され、自動伸縮を止められます",
+    },
+    maxLength: {
+      control: { type: "number" },
+      description:
+        "文字数カウンターの上限値。ネイティブの `maxlength` と違い**入力自体は制限しません**",
+    },
+    required: {
+      description:
+        "ラベルに「必須」バッジを表示し、入力欄に `aria-required` を付与します",
+    },
+    onChange: {
+      name: "change",
+      description:
+        "入力が確定したとき（ネイティブの `change` と同じタイミング）。新しい値は `event.target.value` で取得します",
+      table: { category: "Events" },
+    },
+    errorSlot: {
+      name: 'slot="error"',
+      control: "radio",
+      options: ["none", "text", "withLink", "multiple"],
+      mapping: {
+        none: nothing,
+        text: html`<span slot="error">エラーテキストが入ります</span>`,
+        withLink: html`<span slot="error"
+          >エラーが発生しました。詳しくは<a href="#">こちら</a
+          >をご覧ください。</span
+        >`,
+        multiple: html`<span slot="error">入力内容に誤りがあります</span>
+          <span slot="error">使用できない文字が含まれています</span>
+          <span slot="error">1000文字以内で入力してください</span>`,
+      },
+      table: { category: "Slots" },
+    },
+  },
+  render: ({
+    text,
+    supportText,
+    value,
+    placeholder,
+    size,
+    minRows,
+    maxRows,
+    disabled,
+    required,
+    showCount,
+    maxLength,
+    name,
+    onChange,
+    errorSlot,
+  }) => html`
+    <mi-text-area-unit
+      text=${text}
+      support-text=${supportText}
+      .value=${value}
+      placeholder=${placeholder}
+      size=${size}
+      name=${name}
+      .minRows=${minRows}
+      .maxRows=${maxRows}
+      .maxLength=${maxLength}
+      ?disabled=${disabled}
+      ?required=${required}
+      ?show-count=${showCount}
+      @change=${onChange}
+    >
+      ${errorSlot}
+    </mi-text-area-unit>
+  `,
+  tags: ["!dev-only"],
+};
+export default meta;
+
+type Story = StoryObj<MiTextAreaUnitStory>;
+
+export const Default: Story = {};
+
+/** `required` を指定すると、ラベルの横に「必須」バッジが表示されます。 */
+export const Required: Story = {
+  args: {
+    required: true,
+  },
+};
+
+/** ラベルの下に補足テキストを表示できます。 */
+export const WithSupportText: Story = {
+  args: {
+    supportText: "500文字以内で入力してください",
+    required: true,
+  },
+};
+
+/** 文字数カウンターは入力エリアの外側（下）に表示されます。 */
+export const WithCount: Story = {
+  args: {
+    showCount: true,
+    maxLength: 100,
+  },
+};
+
+/** エラーメッセージも入力エリアの外側に表示され、入力エリアの高さは変わりません。 */
+export const WithError: Story = {
+  args: {
+    showCount: true,
+    maxLength: 10,
+    value: "上限を超えた入力の例です。",
+    errorSlot: "multiple" as unknown as TemplateResult,
+  },
+};
+
+/** 入力量に応じて高さが伸び、`max-rows` で止まります。 */
+export const AutoGrow: Story = {
+  args: {
+    maxRows: 6,
+    placeholder: "入力すると6行分まで高さが伸びます",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    value: "入力できません",
+  },
+};
+
+export const All: Story = {
+  render: () => html`
+    <div
+      style="display: flex; flex-direction: column; gap: 24px; max-width: 400px;"
+    >
+      ${sizes.map(
+        (size) => html`
+          <div>
+            <strong>${size}</strong>
+            <div
+              style="display: flex; flex-direction: column; gap: 16px; margin-block-start: 8px;"
+            >
+              <mi-text-area-unit
+                text="通常"
+                size=${size}
+                placeholder="プレースホルダー"
+              ></mi-text-area-unit>
+              <mi-text-area-unit
+                text="必須"
+                size=${size}
+                placeholder="プレースホルダー"
+                required
+              ></mi-text-area-unit>
+              <mi-text-area-unit
+                text="文字数カウンターあり"
+                size=${size}
+                show-count
+                .maxLength=${100}
+              ></mi-text-area-unit>
+              <mi-text-area-unit text="エラー" size=${size}>
+                <span slot="error">エラーメッセージ</span>
+              </mi-text-area-unit>
+              <mi-text-area-unit
+                text="無効"
+                size=${size}
+                value="入力できません"
+                disabled
+              ></mi-text-area-unit>
+            </div>
+          </div>
+        `,
+      )}
+    </div>
+  `,
+};

--- a/stories/text-area/mi-text-area.story.ts
+++ b/stories/text-area/mi-text-area.story.ts
@@ -1,0 +1,242 @@
+import "../../src/components/text-area/mi-text-area";
+
+import type { Meta, StoryObj } from "@storybook/web-components-vite";
+import type { TemplateResult } from "lit";
+import { html, nothing } from "lit";
+import { action } from "storybook/actions";
+
+import {
+  type MiTextArea,
+  sizes,
+} from "../../src/components/text-area/mi-text-area";
+
+/** Storybook Actions / Slots 用（コンポーネントの公開 API 外） */
+type MiTextAreaStory = MiTextArea & {
+  onChange?: (...args: unknown[]) => void;
+  errorSlot: TemplateResult | typeof nothing;
+};
+
+const meta: Meta<MiTextAreaStory> = {
+  component: "mi-text-area",
+  title: "Components/TextArea/mi-text-area",
+  args: {
+    value: "",
+    placeholder: "テキストを入力してください",
+    label: "",
+    description: "",
+    size: "medium",
+    minRows: 2,
+    maxRows: null,
+    disabled: false,
+    required: false,
+    showCount: false,
+    maxLength: null,
+    name: "body",
+    onChange: action("change"),
+    errorSlot: "none" as unknown as TemplateResult,
+  },
+  argTypes: {
+    size: {
+      control: { type: "select" },
+      options: [...sizes],
+    },
+    minRows: {
+      control: { type: "number" },
+      description:
+        "入力エリアの最小の行数。デザイン仕様上 2 行が下限のため、2 未満を指定すると 2 に正規化されます",
+    },
+    maxRows: {
+      control: { type: "number" },
+      description:
+        "自動で伸びる上限の行数。未指定なら伸び続けます。指定するとその行数で止まり、以降はテキストエリア内がスクロールします",
+    },
+    maxLength: {
+      control: { type: "number" },
+      description:
+        "文字数カウンターの上限値。ネイティブの `maxlength` と違い**入力自体は制限しません**（超過時はカウンターを強調表示するのみ）。文字数はコードポイント単位で数えるため絵文字（😀）は1文字です。改行はカウンター上1文字ですが、フォーム送信時は `\r\n` になるためサーバーが受け取る文字数は改行の数だけ多くなります",
+    },
+    showCount: {
+      description:
+        "文字数カウンターを表示します。`max-length` と併用すると `現在値 / 上限` の形式になります",
+    },
+    required: {
+      description:
+        '入力欄に `aria-required="true"` を付与します。ネイティブの `required` は付けないため、ブラウザによる送信時バリデーションは行いません',
+    },
+    description: {
+      description:
+        "スクリーンリーダーに読み上げる欄の説明。視覚的には表示されず `aria-describedby` から参照されます（mi-text-area-unit が support-text をここに渡します）",
+    },
+    label: {
+      description:
+        "内部の `textarea` に設定する aria-label。Shadow DOM の外から `<label for>` では紐付けられないため、スクリーンリーダー向けの名前はこの属性で渡します",
+    },
+    errorSlot: {
+      name: 'slot="error"',
+      control: "radio",
+      options: ["none", "text", "withLink", "multiple"],
+      mapping: {
+        none: nothing,
+        text: html`<span slot="error">エラーテキストが入ります</span>`,
+        withLink: html`<span slot="error"
+          >エラーが発生しました。詳しくは<a href="#">こちら</a
+          >をご覧ください。</span
+        >`,
+        multiple: html`<span slot="error">入力内容に誤りがあります</span>
+          <span slot="error">使用できない文字が含まれています</span>
+          <span slot="error">1000文字以内で入力してください</span>`,
+      },
+      table: { category: "Slots" },
+    },
+    onChange: {
+      name: "change",
+      description:
+        "入力が確定したとき（ネイティブの `change` と同じタイミング）。新しい値は `event.target.value` で取得します",
+      table: { category: "Events" },
+    },
+  },
+  render: ({
+    value,
+    placeholder,
+    label,
+    description,
+    size,
+    minRows,
+    maxRows,
+    disabled,
+    required,
+    showCount,
+    maxLength,
+    name,
+    onChange,
+    errorSlot,
+  }) => html`
+    <mi-text-area
+      .value=${value}
+      placeholder=${placeholder}
+      label=${label}
+      description=${description}
+      size=${size}
+      name=${name}
+      .minRows=${minRows}
+      .maxRows=${maxRows}
+      ?disabled=${disabled}
+      ?required=${required}
+      ?show-count=${showCount}
+      .maxLength=${maxLength}
+      @change=${onChange}
+    >
+      ${errorSlot}
+    </mi-text-area>
+  `,
+  tags: ["!dev-only"],
+};
+export default meta;
+
+type Story = StoryObj<MiTextAreaStory>;
+
+export const Default: Story = {};
+
+/** 文字数カウンターを表示します。上限を超えても入力は制限されず、現在値が強調表示されます。 */
+export const WithCount: Story = {
+  args: {
+    showCount: true,
+    maxLength: 100,
+  },
+};
+
+/** 上限を超えた状態です。カウンターの現在値のみが赤字・太字になります。 */
+export const OverMaxLength: Story = {
+  args: {
+    showCount: true,
+    maxLength: 10,
+    value: "上限を超えた入力の例です。",
+  },
+};
+
+/** `slot="error"` に渡した要素が、エラーメッセージとして下部に表示されます。 */
+export const WithError: Story = {
+  render: ({ placeholder, size, minRows, onChange }) => html`
+    <mi-text-area
+      placeholder=${placeholder}
+      size=${size}
+      .minRows=${minRows}
+      @change=${onChange}
+    >
+      <span slot="error">入力内容に誤りがあります。</span>
+      <span slot="error">詳しくは<a href="#">こちら</a>をご確認ください。</span>
+    </mi-text-area>
+  `,
+};
+
+/**
+ * `required` を指定すると入力欄に `aria-required="true"` が付きます。
+ * ラベルを持たないコンポーネントのため、見た目は変わりません。
+ */
+export const Required: Story = {
+  args: {
+    required: true,
+  },
+};
+
+/**
+ * 入力量に応じて高さが伸びます。`max-rows` に達すると止まり、以降はスクロールします。`min-rows` と同じ値にすると高さが固定され、自動伸縮を止められます。
+ * 下限は `min-rows`（デフォルト2行）です。
+ */
+export const AutoGrow: Story = {
+  args: {
+    maxRows: 6,
+    placeholder: "入力すると6行分まで高さが伸びます",
+  },
+};
+
+/** `min-rows` で下限を広げた状態です。2 未満を指定しても2行分になります。 */
+export const MinRows: Story = {
+  args: {
+    minRows: 4,
+    maxRows: 8,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    value: "入力できません",
+    showCount: true,
+    maxLength: 100,
+  },
+};
+
+export const All: Story = {
+  render: () => html`
+    <div
+      style="display: flex; flex-direction: column; gap: 24px; max-width: 400px;"
+    >
+      ${sizes.map(
+        (size) => html`
+          <div>
+            <strong>${size}</strong>
+            <div
+              style="display: flex; flex-direction: column; gap: 16px; margin-block-start: 8px;"
+            >
+              <mi-text-area
+                size=${size}
+                placeholder="通常"
+                show-count
+                .maxLength=${100}
+              ></mi-text-area>
+              <mi-text-area size=${size} placeholder="エラー">
+                <span slot="error">エラーメッセージ</span>
+              </mi-text-area>
+              <mi-text-area
+                size=${size}
+                placeholder="無効"
+                disabled
+              ></mi-text-area>
+            </div>
+          </div>
+        `,
+      )}
+    </div>
+  `,
+};

--- a/stories/text-field/mi-text-field-unit.story.ts
+++ b/stories/text-field/mi-text-field-unit.story.ts
@@ -71,3 +71,117 @@ export const Default: Story = {
     </mi-text-field-unit>`;
   },
 };
+
+/** `slot="error"` に渡した要素が、テキストフィールドの下にエラーメッセージとして表示されます。 */
+export const WithError: Story = {
+  render: () => html`
+    <mi-text-field-unit
+      text="姓"
+      support-text="サポートテキスト"
+      placeholder="プレースホルダー"
+      name="surname"
+    >
+      <span slot="error">エラーテキストが入ります</span>
+    </mi-text-field-unit>
+  `,
+};
+
+/**
+ * `slot="error"` は複数渡せます。要素ごとに1件のエラーとして、渡した順に表示されます。
+ */
+export const WithMultipleErrors: Story = {
+  render: () => html`
+    <mi-text-field-unit
+      text="姓"
+      placeholder="プレースホルダー"
+      name="surname"
+      value="やまだ"
+    >
+      <span slot="error">姓を入力してください</span>
+      <span slot="error">全角文字は使用できません</span>
+      <span slot="error">20文字以内で入力してください</span>
+    </mi-text-field-unit>
+  `,
+};
+
+/** `required` を指定すると、ラベルの横に「必須」バッジが表示されます。 */
+export const Required: Story = {
+  render: () => html`
+    <mi-text-field-unit
+      text="姓"
+      support-text="サポートテキスト"
+      placeholder="プレースホルダー"
+      name="surname"
+      required
+    ></mi-text-field-unit>
+  `,
+};
+
+/** `disabled` を指定すると入力できません。エラーがあっても表示されません。 */
+export const Disabled: Story = {
+  render: () => html`
+    <mi-text-field-unit text="姓" value="入力できません" disabled>
+      <span slot="error">disabled のときはエラーを表示しません</span>
+    </mi-text-field-unit>
+  `,
+};
+
+export const All: Story = {
+  render: () => html`
+    <div
+      style="display: flex; flex-direction: column; gap: 24px; max-width: 400px;"
+    >
+      <div>
+        <p style="margin: 0 0 4px; font-size: 12px; color: #666;">通常</p>
+        <mi-text-field-unit
+          text="姓"
+          placeholder="プレースホルダー"
+        ></mi-text-field-unit>
+      </div>
+      <div>
+        <p style="margin: 0 0 4px; font-size: 12px; color: #666;">
+          サポートテキストあり
+        </p>
+        <mi-text-field-unit
+          text="姓"
+          support-text="サポートテキスト"
+          placeholder="プレースホルダー"
+        ></mi-text-field-unit>
+      </div>
+      <div>
+        <p style="margin: 0 0 4px; font-size: 12px; color: #666;">必須</p>
+        <mi-text-field-unit
+          text="姓"
+          placeholder="プレースホルダー"
+          required
+        ></mi-text-field-unit>
+      </div>
+      <div>
+        <p style="margin: 0 0 4px; font-size: 12px; color: #666;">
+          エラー（1件）
+        </p>
+        <mi-text-field-unit text="姓" placeholder="プレースホルダー">
+          <span slot="error">エラーテキストが入ります</span>
+        </mi-text-field-unit>
+      </div>
+      <div>
+        <p style="margin: 0 0 4px; font-size: 12px; color: #666;">
+          エラー（複数件）
+        </p>
+        <mi-text-field-unit text="姓" placeholder="プレースホルダー">
+          <span slot="error">姓を入力してください</span>
+          <span slot="error">全角文字は使用できません</span>
+          <span slot="error">20文字以内で入力してください</span>
+        </mi-text-field-unit>
+      </div>
+      <div>
+        <p style="margin: 0 0 4px; font-size: 12px; color: #666;">disabled</p>
+        <mi-text-field-unit
+          text="姓"
+          value="入力できません"
+          disabled
+        ></mi-text-field-unit>
+      </div>
+    </div>
+  `,
+};

--- a/stories/text-field/mi-text-field.story.ts
+++ b/stories/text-field/mi-text-field.story.ts
@@ -80,3 +80,124 @@ export const Default: Story = {
     </mi-text-field>`;
   },
 };
+
+/** `slot="error"` に渡した要素が、テキストフィールドの下にエラーメッセージとして表示されます。 */
+export const WithError: Story = {
+  render: () => html`
+    <mi-text-field placeholder="プレースホルダー" name="surname">
+      <span slot="error">エラーテキストが入ります</span>
+    </mi-text-field>
+  `,
+};
+
+/**
+ * `slot="error"` は複数渡せます。要素ごとに1件のエラーとして、渡した順に表示されます。
+ */
+export const WithMultipleErrors: Story = {
+  render: () => html`
+    <mi-text-field placeholder="プレースホルダー" name="surname" value="やまだ">
+      <span slot="error">姓を入力してください</span>
+      <span slot="error">全角文字は使用できません</span>
+      <span slot="error">20文字以内で入力してください</span>
+    </mi-text-field>
+  `,
+};
+
+/** エラーメッセージ内の HTML 構造は保持されるため、リンクを含められます。 */
+export const WithErrorLink: Story = {
+  render: () => html`
+    <mi-text-field placeholder="プレースホルダー" name="surname">
+      <span slot="error"
+        >エラーが発生しました。詳しくは<a href="#">こちら</a
+        >をご覧ください。</span
+      >
+    </mi-text-field>
+  `,
+};
+
+/**
+ * `required` を指定すると入力欄に `aria-required="true"` が付きます。
+ * このコンポーネント自体はラベルを持たないため見た目は変わりません。
+ * 「必須」バッジを表示する場合は `mi-text-field-unit` を使用してください。
+ */
+export const Required: Story = {
+  render: () => html`
+    <mi-text-field
+      placeholder="プレースホルダー"
+      name="surname"
+      required
+    ></mi-text-field>
+  `,
+};
+
+/** `disabled` を指定すると入力できません。エラーがあっても表示されません。 */
+export const Disabled: Story = {
+  render: () => html`
+    <mi-text-field name="surname" value="入力できません" disabled>
+      <span slot="error">disabled のときはエラーを表示しません</span>
+    </mi-text-field>
+  `,
+};
+
+/** `type="password"` を指定すると入力内容が伏せ字になります。 */
+export const Password: Story = {
+  render: () => html`
+    <mi-text-field
+      type="password"
+      placeholder="パスワード"
+      name="password"
+      value="password1234"
+      autocomplete="current-password"
+    ></mi-text-field>
+  `,
+};
+
+export const All: Story = {
+  render: () => html`
+    <div
+      style="display: flex; flex-direction: column; gap: 24px; max-width: 400px;"
+    >
+      <div>
+        <p style="margin: 0 0 4px; font-size: 12px; color: #666;">通常</p>
+        <mi-text-field placeholder="プレースホルダー"></mi-text-field>
+      </div>
+      <div>
+        <p style="margin: 0 0 4px; font-size: 12px; color: #666;">
+          エラー（1件）
+        </p>
+        <mi-text-field placeholder="プレースホルダー">
+          <span slot="error">エラーテキストが入ります</span>
+        </mi-text-field>
+      </div>
+      <div>
+        <p style="margin: 0 0 4px; font-size: 12px; color: #666;">
+          エラー（複数件）
+        </p>
+        <mi-text-field placeholder="プレースホルダー">
+          <span slot="error">姓を入力してください</span>
+          <span slot="error">全角文字は使用できません</span>
+          <span slot="error">20文字以内で入力してください</span>
+        </mi-text-field>
+      </div>
+      <div>
+        <p style="margin: 0 0 4px; font-size: 12px; color: #666;">
+          エラー（リンクあり）
+        </p>
+        <mi-text-field placeholder="プレースホルダー">
+          <span slot="error"
+            >エラーが発生しました。詳しくは<a href="#">こちら</a
+            >をご覧ください。</span
+          >
+        </mi-text-field>
+      </div>
+      <div>
+        <p style="margin: 0 0 4px; font-size: 12px; color: #666;">password</p>
+        <mi-text-field type="password" value="password1234"></mi-text-field>
+      </div>
+      <div>
+        <p style="margin: 0 0 4px; font-size: 12px; color: #666;">disabled</p>
+        <mi-text-field value="入力できません" disabled></mi-text-field>
+      </div>
+    </div>
+  `,
+};

--- a/tests/button/mi-button.test.ts
+++ b/tests/button/mi-button.test.ts
@@ -650,7 +650,10 @@ describe("mi-button", () => {
 
       const miButton = getMiButton();
       let clickCount = 0;
-      miButton.addEventListener("click", () => {
+      miButton.addEventListener("click", (e) => {
+        // preventDefault しないとテスト用の iframe が href 先へ遷移し、
+        // Vitest が iframe との接続を失って実行全体が中断する
+        e.preventDefault();
         clickCount++;
       });
 

--- a/tests/button/mi-icon-button.test.ts
+++ b/tests/button/mi-icon-button.test.ts
@@ -404,7 +404,10 @@ describe("mi-icon-button", () => {
 
       const el = getMiIconButton();
       let clickCount = 0;
-      el.addEventListener("click", () => {
+      el.addEventListener("click", (e) => {
+        // preventDefault しないとテスト用の iframe が href 先へ遷移し、
+        // Vitest が iframe との接続を失って実行全体が中断する
+        e.preventDefault();
         clickCount++;
       });
 

--- a/tests/label-unit.test.ts
+++ b/tests/label-unit.test.ts
@@ -22,6 +22,21 @@ describe("mi-label-unit", () => {
     expect(a.element().textContent).toBe("サポート");
   });
 
+  test("ラベルと補足テキストの高さが環境に依存しない", async () => {
+    // line-height を明示しないと normal（フォント依存）になり、OS によって高さが変わる。
+    // Figma の指定は label 21px（14px × 150%）/ 補足 16px（12px × 130% = 15.6px）
+    document.body.innerHTML = `<mi-label-unit text="ラベル" support-text="補足"></mi-label-unit>`;
+    await customElements.whenDefined("mi-label-unit");
+    const sut = document.querySelector("mi-label-unit")!;
+    await sut.updateComplete;
+
+    const label = sut.shadowRoot!.querySelector(".label")!;
+    const support = sut.shadowRoot!.querySelector(".support")!;
+
+    expect(label.getBoundingClientRect().height).toBe(21);
+    expect(support.getBoundingClientRect().height).toBeCloseTo(15.6, 1);
+  });
+
   test("required属性を指定すると、必須バッジが表示される", async () => {
     document.body.innerHTML = `<mi-label-unit text="ラベル" required></mi-label-unit>`;
     await customElements.whenDefined("mi-label-unit");

--- a/tests/text-area/mi-text-area-unit.test.ts
+++ b/tests/text-area/mi-text-area-unit.test.ts
@@ -1,0 +1,456 @@
+import "../../src/components/text-area/mi-text-area-unit";
+
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { page } from "vitest/browser";
+
+import type { MiTextAreaUnit } from "../../src/components/text-area/mi-text-area-unit";
+
+const setup = async (html: string) => {
+  document.body.innerHTML = html;
+  await customElements.whenDefined("mi-text-area-unit");
+  await customElements.whenDefined("mi-text-area");
+
+  const element = document.querySelector("mi-text-area-unit")!;
+  await element.updateComplete;
+
+  const textArea = element.shadowRoot!.querySelector("mi-text-area")!;
+  await textArea.updateComplete;
+
+  return {
+    element,
+    labelUnit: element.shadowRoot!.querySelector("mi-label-unit")!,
+    textArea,
+    textarea: textArea.shadowRoot!.querySelector("textarea")!,
+  };
+};
+
+/** slotchange と内側コンポーネントの再描画が落ち着くのを待つ */
+const settle = async (element: MiTextAreaUnit) => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await element.updateComplete;
+  const textArea = element.shadowRoot!.querySelector("mi-text-area")!;
+  await textArea.updateComplete;
+  return textArea;
+};
+
+/**
+ * ブラウザモードの既定の viewport は 414px（= 720px 以下）なので、
+ * 指定しないとスマートフォン用スタイルで動いてしまう。
+ * mi-text-area.test.ts と同じく、既定は desktop 幅で検証する。
+ */
+const DESKTOP_WIDTH = 1280;
+const VIEWPORT_HEIGHT = 900;
+
+describe("mi-text-area-unit", () => {
+  beforeEach(async () => {
+    await page.viewport(DESKTOP_WIDTH, VIEWPORT_HEIGHT);
+  });
+  describe("ラベル", () => {
+    test("text がラベルとして表示される", async () => {
+      const { labelUnit } = await setup(
+        `<mi-text-area-unit text="自己紹介"></mi-text-area-unit>`,
+      );
+      await labelUnit.updateComplete;
+
+      expect(labelUnit.getAttribute("text")).toBe("自己紹介");
+      expect(
+        labelUnit.shadowRoot!.querySelector(".label")!.textContent,
+      ).toContain("自己紹介");
+    });
+
+    test("text がない場合はラベルを表示しない", async () => {
+      const { labelUnit } = await setup(
+        `<mi-text-area-unit></mi-text-area-unit>`,
+      );
+
+      expect(labelUnit.classList.contains("none")).toBe(true);
+    });
+
+    test("support-text がラベルの下に表示される", async () => {
+      const { labelUnit } = await setup(
+        `<mi-text-area-unit text="自己紹介" support-text="500文字以内で入力してください"></mi-text-area-unit>`,
+      );
+      await labelUnit.updateComplete;
+
+      expect(
+        labelUnit.shadowRoot!.querySelector(".support")!.textContent,
+      ).toContain("500文字以内で入力してください");
+    });
+
+    test("text がなく support-text だけでもラベル領域を表示する", async () => {
+      const { labelUnit } = await setup(
+        `<mi-text-area-unit support-text="補足だけ"></mi-text-area-unit>`,
+      );
+      await labelUnit.updateComplete;
+
+      expect(labelUnit.classList.contains("none")).toBe(false);
+      expect(
+        labelUnit.shadowRoot!.querySelector(".support")!.textContent,
+      ).toContain("補足だけ");
+    });
+
+    test("text も support-text もない場合はラベル領域を隠す", async () => {
+      const { labelUnit } = await setup(
+        `<mi-text-area-unit></mi-text-area-unit>`,
+      );
+
+      expect(labelUnit.classList.contains("none")).toBe(true);
+    });
+
+    test("support-text が読み上げでも欄の説明として関連付く", async () => {
+      // 見えている補足テキストは mi-label-unit の Shadow DOM 内にあり
+      // aria-describedby では参照できないため、同じ文言を description として渡している
+      const { textArea, textarea } = await setup(
+        `<mi-text-area-unit text="自己紹介" support-text="500文字以内で入力してください"></mi-text-area-unit>`,
+      );
+      await textArea.updateComplete;
+
+      const ids = textarea.getAttribute("aria-describedby")!.split(" ");
+      expect(ids).toContain("description");
+
+      const description = textArea.shadowRoot!.getElementById("description")!;
+      expect(description.textContent?.trim()).toBe(
+        "500文字以内で入力してください",
+      );
+    });
+
+    test("text が内側の textarea の aria-label にも渡る", async () => {
+      // mi-label-unit のテキストは別の Shadow DOM 内にあり aria-labelledby では参照できないため
+      const { textarea } = await setup(
+        `<mi-text-area-unit text="自己紹介"></mi-text-area-unit>`,
+      );
+
+      expect(textarea.getAttribute("aria-label")).toBe("自己紹介");
+    });
+  });
+
+  describe("required", () => {
+    test("ラベルに必須バッジが表示される", async () => {
+      const { labelUnit } = await setup(
+        `<mi-text-area-unit text="自己紹介" required></mi-text-area-unit>`,
+      );
+      await labelUnit.updateComplete;
+
+      expect(
+        labelUnit.shadowRoot!.querySelector(".required")?.textContent,
+      ).toBe("必須");
+    });
+
+    test("入力欄に aria-required が付く", async () => {
+      const { textarea } = await setup(
+        `<mi-text-area-unit text="自己紹介" required></mi-text-area-unit>`,
+      );
+
+      expect(textarea.getAttribute("aria-required")).toBe("true");
+    });
+  });
+
+  describe("値とフォーム連携", () => {
+    test("value が内側の textarea に反映される", async () => {
+      const { textarea } = await setup(
+        `<mi-text-area-unit value="初期値"></mi-text-area-unit>`,
+      );
+
+      expect(textarea.value).toBe("初期値");
+    });
+
+    test("入力すると value が更新される", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area-unit></mi-text-area-unit>`,
+      );
+
+      await page.elementLocator(textarea).fill("入力したテキスト");
+
+      expect(element.value).toBe("入力したテキスト");
+    });
+
+    test("入力すると form の送信値に反映される", async () => {
+      document.body.innerHTML = `
+        <form id="form">
+          <mi-text-area-unit name="body"></mi-text-area-unit>
+        </form>`;
+      await customElements.whenDefined("mi-text-area-unit");
+      const element = document.querySelector("mi-text-area-unit")!;
+      await element.updateComplete;
+      const textArea = element.shadowRoot!.querySelector("mi-text-area")!;
+      await textArea.updateComplete;
+      const textarea = textArea.shadowRoot!.querySelector("textarea")!;
+
+      await page.elementLocator(textarea).fill("送信されるテキスト");
+      await element.updateComplete;
+
+      const form = document.getElementById("form") as HTMLFormElement;
+      expect(new FormData(form).get("body")).toBe("送信されるテキスト");
+    });
+
+    test("フォームをリセットすると初期値に戻る", async () => {
+      document.body.innerHTML = `
+        <form id="form">
+          <mi-text-area-unit name="body" value="初期値"></mi-text-area-unit>
+        </form>`;
+      await customElements.whenDefined("mi-text-area-unit");
+      const element = document.querySelector("mi-text-area-unit")!;
+      await element.updateComplete;
+
+      element.value = "編集後のテキスト";
+      await element.updateComplete;
+
+      (document.getElementById("form") as HTMLFormElement).reset();
+      await element.updateComplete;
+
+      expect(element.value).toBe("初期値");
+    });
+  });
+
+  describe("エラー表示", () => {
+    test('slot="error" が内側のテキストエリアに流れる', async () => {
+      const { textArea } = await setup(
+        `<mi-text-area-unit text="自己紹介">
+          <span slot="error">入力内容に誤りがあります</span>
+        </mi-text-area-unit>`,
+      );
+      await textArea.updateComplete;
+
+      const helperTexts =
+        textArea.shadowRoot!.querySelectorAll("mi-helper-text");
+      expect(helperTexts.length).toBe(1);
+      expect(helperTexts[0].textContent?.trim()).toBe(
+        "入力内容に誤りがあります",
+      );
+    });
+
+    test("複数のエラーがすべて表示される", async () => {
+      const { textArea } = await setup(
+        `<mi-text-area-unit text="自己紹介">
+          <span slot="error">エラー1</span>
+          <span slot="error">エラー2</span>
+          <span slot="error">エラー3</span>
+        </mi-text-area-unit>`,
+      );
+      await textArea.updateComplete;
+
+      expect(
+        textArea.shadowRoot!.querySelectorAll("mi-helper-text").length,
+      ).toBe(3);
+    });
+
+    test("エラー内のリンクが保持される", async () => {
+      const { textArea } = await setup(
+        `<mi-text-area-unit text="自己紹介">
+          <span slot="error">詳しくは<a href="/help">こちら</a></span>
+        </mi-text-area-unit>`,
+      );
+      await textArea.updateComplete;
+
+      const helperText = textArea.shadowRoot!.querySelector("mi-helper-text")!;
+      expect(helperText.querySelector("a")?.getAttribute("href")).toBe("/help");
+    });
+
+    test("後から追加したエラーが表示される", async () => {
+      const { element } = await setup(
+        `<mi-text-area-unit text="自己紹介"></mi-text-area-unit>`,
+      );
+
+      const span = document.createElement("span");
+      span.slot = "error";
+      span.textContent = "後から追加したエラー";
+      element.appendChild(span);
+
+      const textArea = await settle(element);
+
+      expect(
+        textArea.shadowRoot!.querySelectorAll("mi-helper-text").length,
+      ).toBe(1);
+    });
+  });
+
+  describe("テキストエリアへの委譲", () => {
+    test("size が反映される", async () => {
+      const { textarea } = await setup(
+        `<mi-text-area-unit size="large"></mi-text-area-unit>`,
+      );
+
+      expect(textarea.dataset.size).toBe("large");
+    });
+
+    test("placeholder / disabled が反映される", async () => {
+      const { textarea } = await setup(
+        `<mi-text-area-unit placeholder="入力してください" disabled></mi-text-area-unit>`,
+      );
+
+      expect(textarea.placeholder).toBe("入力してください");
+      expect(textarea.disabled).toBe(true);
+    });
+
+    test("min-rows / max-rows が反映される", async () => {
+      const { textarea } = await setup(
+        `<mi-text-area-unit min-rows="4" max-rows="8"></mi-text-area-unit>`,
+      );
+
+      expect(textarea.rows).toBe(4);
+      expect(textarea.style.getPropertyValue("--text-area-min-rows")).toBe("4");
+      expect(textarea.style.getPropertyValue("--text-area-max-rows")).toBe("8");
+    });
+
+    test("show-count / max-length が反映される", async () => {
+      const { textArea } = await setup(
+        `<mi-text-area-unit show-count max-length="100" value="あいう"></mi-text-area-unit>`,
+      );
+      await textArea.updateComplete;
+
+      const count = textArea.shadowRoot!.querySelector(".count")!;
+      expect(count.textContent?.replace(/\s/g, "")).toBe("3/100");
+    });
+  });
+
+  describe("レイアウトと行数の正規化", () => {
+    test("flex コンテナの中でも潰れずコンテナ幅に追従する", async () => {
+      document.body.innerHTML = `<div style="display:flex; width:200px"><mi-text-area-unit text="ラベル"></mi-text-area-unit></div>`;
+      await customElements.whenDefined("mi-text-area-unit");
+      const element = document.querySelector("mi-text-area-unit")!;
+      await element.updateComplete;
+
+      expect(Math.round(element.getBoundingClientRect().width)).toBe(200);
+    });
+
+    test("min-rows に2未満を指定すると unit 側のプロパティも2に正規化される", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area-unit min-rows="1"></mi-text-area-unit>`,
+      );
+
+      expect(element.minRows).toBe(2);
+      expect(element.getAttribute("min-rows")).toBe("2");
+      expect(textarea.rows).toBe(2);
+    });
+
+    test("値のない max-rows は unit 側でも上限なしになる", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area-unit max-rows></mi-text-area-unit>`,
+      );
+
+      expect(element.maxRows).toBe(null);
+      expect(textarea.hasAttribute("data-has-max-rows")).toBe(false);
+    });
+
+    test("max-rows が min-rows より小さい場合は min-rows に揃う", async () => {
+      const { element } = await setup(
+        `<mi-text-area-unit min-rows="5" max-rows="3"></mi-text-area-unit>`,
+      );
+
+      expect(element.maxRows).toBe(5);
+    });
+  });
+
+  describe("Figma との寸法照合", () => {
+    const heightOf = (e: Element) =>
+      Math.round(e.getBoundingClientRect().height);
+
+    test("ラベルとテキストエリアの間隔が Figma の 8px と一致する", async () => {
+      const { labelUnit, textArea } = await setup(
+        `<div style="width:256px"><mi-text-area-unit text="ラベル" min-rows="3"></mi-text-area-unit></div>`,
+      );
+      await labelUnit.updateComplete;
+
+      const gap =
+        textArea.getBoundingClientRect().top -
+        labelUnit.getBoundingClientRect().bottom;
+      expect(Math.round(gap)).toBe(8);
+    });
+
+    test("desktop / medium の全体高さが Figma の 108px と一致する", async () => {
+      // Figma: label 21 + 間隔 8 + テキストエリア 79（3行分）
+      const { element, labelUnit } = await setup(
+        `<div style="width:256px"><mi-text-area-unit text="ラベル" min-rows="3"></mi-text-area-unit></div>`,
+      );
+      await labelUnit.updateComplete;
+
+      expect(heightOf(element)).toBe(108);
+    });
+
+    test("desktop / large（補足テキストあり）の全体高さ", async () => {
+      // Figma は 137px（label 41 + 間隔 8 + テキストエリア 88）だが実装は 139px。
+      // 差の 2px は mi-label-unit の .support に line-height の指定がなく
+      // 補足テキストが 16px ではなく 18px になっているため（別課題）。
+      const { element, labelUnit } = await setup(
+        `<div style="width:256px"><mi-text-area-unit text="ラベル" support-text="補足" size="large" min-rows="3"></mi-text-area-unit></div>`,
+      );
+      await labelUnit.updateComplete;
+
+      expect(heightOf(element)).toBe(139);
+    });
+  });
+
+  describe("イベント", () => {
+    test("input イベントがホスト要素の外まで届く", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area-unit></mi-text-area-unit>`,
+      );
+
+      const handler = vi.fn();
+      element.addEventListener("input", handler);
+
+      await page.elementLocator(textarea).fill("abc");
+
+      expect(handler).toHaveBeenCalled();
+    });
+
+    test("change が1回だけ再発火され、ネイティブと同じ bubbles / composed になる", async () => {
+      document.body.innerHTML = `<div id="ancestor"><mi-text-area-unit></mi-text-area-unit></div>`;
+      await customElements.whenDefined("mi-text-area-unit");
+      const element = document.querySelector("mi-text-area-unit")!;
+      await element.updateComplete;
+      const textArea = element.shadowRoot!.querySelector("mi-text-area")!;
+      await textArea.updateComplete;
+      const textarea = textArea.shadowRoot!.querySelector("textarea")!;
+
+      const received: Event[] = [];
+      element.addEventListener("change", (e) => received.push(e));
+      const onAncestor = vi.fn();
+      document
+        .getElementById("ancestor")!
+        .addEventListener("change", onAncestor);
+
+      // value の同期は input で起きるため、実際の操作と同じ順序で発火させる
+      textarea.value = "abc";
+      textarea.dispatchEvent(
+        new Event("input", { bubbles: true, composed: true }),
+      );
+      await element.updateComplete;
+      textarea.dispatchEvent(new Event("change", { bubbles: true }));
+      await element.updateComplete;
+
+      // 内側の change を止めてから発火し直すので、二重に飛ばない
+      expect(received).toHaveLength(1);
+      expect(received[0].bubbles).toBe(true);
+      expect(received[0].composed).toBe(false);
+      expect(onAncestor).toHaveBeenCalledTimes(1);
+      expect(element.value).toBe("abc");
+    });
+  });
+
+  test("autofocus が内側の textarea に委譲される", async () => {
+    const { textarea } = await setup(
+      `<mi-text-area-unit autofocus></mi-text-area-unit>`,
+    );
+
+    expect(textarea.hasAttribute("autofocus")).toBe(true);
+  });
+
+  test("autofocus を指定しない場合は付かない", async () => {
+    const { textarea } = await setup(`<mi-text-area-unit></mi-text-area-unit>`);
+
+    expect(textarea.hasAttribute("autofocus")).toBe(false);
+  });
+
+  test("フォーカスすると内側の textarea にフォーカスが移る", async () => {
+    const { element, textarea } = await setup(
+      `<mi-text-area-unit></mi-text-area-unit>`,
+    );
+
+    element.focus();
+
+    expect(element.shadowRoot!.activeElement?.shadowRoot?.activeElement).toBe(
+      textarea,
+    );
+  });
+});

--- a/tests/text-area/mi-text-area-unit.test.ts
+++ b/tests/text-area/mi-text-area-unit.test.ts
@@ -1,6 +1,6 @@
 import "../../src/components/text-area/mi-text-area-unit";
 
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeAll, describe, expect, test, vi } from "vitest";
 import { page } from "vitest/browser";
 
 import type { MiTextAreaUnit } from "../../src/components/text-area/mi-text-area-unit";
@@ -37,12 +37,13 @@ const settle = async (element: MiTextAreaUnit) => {
  * ブラウザモードの既定の viewport は 414px（= 720px 以下）なので、
  * 指定しないとスマートフォン用スタイルで動いてしまう。
  * mi-text-area.test.ts と同じく、既定は desktop 幅で検証する。
+ * viewport の変更は副作用のある操作なので beforeAll で1回だけ呼ぶ。
  */
 const DESKTOP_WIDTH = 1280;
 const VIEWPORT_HEIGHT = 900;
 
 describe("mi-text-area-unit", () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
     await page.viewport(DESKTOP_WIDTH, VIEWPORT_HEIGHT);
   });
   describe("ラベル", () => {

--- a/tests/text-area/mi-text-area-unit.test.ts
+++ b/tests/text-area/mi-text-area-unit.test.ts
@@ -368,16 +368,14 @@ describe("mi-text-area-unit", () => {
       expect(heightOf(element)).toBe(108);
     });
 
-    test("desktop / large（補足テキストあり）の全体高さ", async () => {
-      // Figma は 137px（label 41 + 間隔 8 + テキストエリア 88）だが実装は 139px。
-      // 差の 2px は mi-label-unit の .support に line-height の指定がなく
-      // 補足テキストが 16px ではなく 18px になっているため（別課題）。
+    test("desktop / large（補足テキストあり）の全体高さが Figma の 137px と一致する", async () => {
+      // Figma: label 41（ラベル21 + 間隔4 + 補足15.6）+ 間隔 8 + テキストエリア 88
       const { element, labelUnit } = await setup(
         `<div style="width:256px"><mi-text-area-unit text="ラベル" support-text="補足" size="large" min-rows="3"></mi-text-area-unit></div>`,
       );
       await labelUnit.updateComplete;
 
-      expect(heightOf(element)).toBe(139);
+      expect(heightOf(element)).toBe(137);
     });
   });
 

--- a/tests/text-area/mi-text-area.test.ts
+++ b/tests/text-area/mi-text-area.test.ts
@@ -1,6 +1,14 @@
 import "../../src/components/text-area/mi-text-area";
 
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest";
 import { page } from "vitest/browser";
 
 import type { MiTextArea } from "../../src/components/text-area/mi-text-area";
@@ -23,13 +31,16 @@ const setup = async (html: string) => {
  * 何も指定しないと `@media (width <= 720px)` のスマートフォン用スタイルで動いてしまう。
  * このリポジトリの実装規約は PC ファースト（ブレイクポイントは 720px の1箇所）なので、
  * 既定は desktop 幅で検証し、スマートフォン幅は該当の describe で明示的に切り替える。
+ *
+ * viewport の変更はブラウザに対する副作用のある操作なので、テストごと（beforeEach）ではなく
+ * ファイル/describe 単位（beforeAll）で最小回数だけ呼ぶ。
  */
 const DESKTOP_WIDTH = 1280;
 const PHONE_WIDTH = 414;
 const VIEWPORT_HEIGHT = 900;
 
 describe("mi-text-area", () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
     await page.viewport(DESKTOP_WIDTH, VIEWPORT_HEIGHT);
   });
 
@@ -451,8 +462,13 @@ describe("mi-text-area", () => {
   });
 
   describe("スマートフォン幅（720px 以下）", () => {
-    beforeEach(async () => {
+    beforeAll(async () => {
       await page.viewport(PHONE_WIDTH, VIEWPORT_HEIGHT);
+    });
+
+    // 後続の describe が desktop 前提で動くよう必ず戻す
+    afterAll(async () => {
+      await page.viewport(DESKTOP_WIDTH, VIEWPORT_HEIGHT);
     });
 
     test("2行分の高さがタッチ操作向けに大きくなる", async () => {

--- a/tests/text-area/mi-text-area.test.ts
+++ b/tests/text-area/mi-text-area.test.ts
@@ -1,0 +1,870 @@
+import "../../src/components/text-area/mi-text-area";
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { page } from "vitest/browser";
+
+import type { MiTextArea } from "../../src/components/text-area/mi-text-area";
+
+const setup = async (html: string) => {
+  document.body.innerHTML = html;
+  await customElements.whenDefined("mi-text-area");
+
+  const element = document.querySelector("mi-text-area")!;
+  await element.updateComplete;
+
+  return {
+    element,
+    textarea: element.shadowRoot!.querySelector("textarea")!,
+  };
+};
+
+/**
+ * ブラウザモードの既定の viewport は 414px（= 720px 以下）なので、
+ * 何も指定しないと `@media (width <= 720px)` のスマートフォン用スタイルで動いてしまう。
+ * このリポジトリの実装規約は PC ファースト（ブレイクポイントは 720px の1箇所）なので、
+ * 既定は desktop 幅で検証し、スマートフォン幅は該当の describe で明示的に切り替える。
+ */
+const DESKTOP_WIDTH = 1280;
+const PHONE_WIDTH = 414;
+const VIEWPORT_HEIGHT = 900;
+
+describe("mi-text-area", () => {
+  beforeEach(async () => {
+    await page.viewport(DESKTOP_WIDTH, VIEWPORT_HEIGHT);
+  });
+
+  test("入力すると value が更新される", async () => {
+    const { element, textarea } = await setup(`<mi-text-area></mi-text-area>`);
+
+    await page.elementLocator(textarea).fill("入力したテキスト");
+
+    expect(element.value).toBe("入力したテキスト");
+  });
+
+  test("value を指定すると textarea に反映される", async () => {
+    const { textarea } = await setup(
+      `<mi-text-area value="初期値"></mi-text-area>`,
+    );
+
+    expect(textarea.value).toBe("初期値");
+  });
+
+  test("入力すると form の送信値に反映される", async () => {
+    document.body.innerHTML = `
+      <form id="form">
+        <mi-text-area name="comment"></mi-text-area>
+      </form>
+    `;
+    await customElements.whenDefined("mi-text-area");
+
+    const element = document.querySelector("mi-text-area")!;
+    await element.updateComplete;
+    const textarea = element.shadowRoot!.querySelector("textarea")!;
+
+    await page.elementLocator(textarea).fill("送信される値");
+    await element.updateComplete;
+
+    const formData = new FormData(document.querySelector("form")!);
+    expect(formData.get("comment")).toBe("送信される値");
+  });
+
+  test("placeholder / disabled が textarea に反映される", async () => {
+    const { textarea } = await setup(
+      `<mi-text-area placeholder="入力してください" disabled></mi-text-area>`,
+    );
+
+    expect(textarea.placeholder).toBe("入力してください");
+    expect(textarea.disabled).toBe(true);
+  });
+
+  test("size を指定すると textarea の data-size に反映される", async () => {
+    const { textarea } = await setup(
+      `<mi-text-area size="large"></mi-text-area>`,
+    );
+
+    expect(textarea.dataset.size).toBe("large");
+  });
+
+  test("size を指定しない場合は medium になる", async () => {
+    const { textarea } = await setup(`<mi-text-area></mi-text-area>`);
+
+    expect(textarea.dataset.size).toBe("medium");
+  });
+
+  describe("文字数カウンター", () => {
+    test("show-count を指定しない場合は表示されない", async () => {
+      const { element } = await setup(
+        `<mi-text-area max-length="10"></mi-text-area>`,
+      );
+
+      expect(element.shadowRoot!.querySelector(".count")).toBeNull();
+    });
+
+    test("show-count を指定すると 現在値 / 上限 が表示される", async () => {
+      const { element } = await setup(
+        `<mi-text-area show-count max-length="10" value="あいう"></mi-text-area>`,
+      );
+
+      const count = element.shadowRoot!.querySelector(".count")!;
+      expect(count.textContent?.replace(/\s/g, "")).toBe("3/10");
+    });
+
+    test("max-length がない場合は現在値のみ表示される", async () => {
+      const { element } = await setup(
+        `<mi-text-area show-count value="あいう"></mi-text-area>`,
+      );
+
+      const count = element.shadowRoot!.querySelector(".count")!;
+      expect(count.textContent?.replace(/\s/g, "")).toBe("3");
+    });
+
+    test("上限以内の場合は現在値が強調されない", async () => {
+      const { element } = await setup(
+        `<mi-text-area show-count max-length="3" value="あいう"></mi-text-area>`,
+      );
+
+      const current = element.shadowRoot!.querySelector(".count-current")!;
+      expect(current.classList.contains("over")).toBe(false);
+    });
+
+    test("上限を超えても入力は保持され、現在値が強調される", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area show-count max-length="3"></mi-text-area>`,
+      );
+
+      await page.elementLocator(textarea).fill("あいうえお");
+      await element.updateComplete;
+
+      // ネイティブの maxlength と異なり、上限を超えた入力も切り捨てない
+      expect(element.value).toBe("あいうえお");
+
+      const current = element.shadowRoot!.querySelector(".count-current")!;
+      expect(current.textContent?.trim()).toBe("5");
+      expect(current.classList.contains("over")).toBe(true);
+    });
+
+    test("上限を超えると枠線がエラー表示になり aria-invalid が true になる", async () => {
+      const { textarea } = await setup(
+        `<mi-text-area show-count max-length="3" value="あいうえお"></mi-text-area>`,
+      );
+
+      expect(textarea.classList.contains("error")).toBe(true);
+      expect(textarea.getAttribute("aria-invalid")).toBe("true");
+    });
+
+    test("disabled の場合は超過してもエラー表示にならない", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area show-count max-length="3" value="あいうえお" disabled></mi-text-area>`,
+      );
+
+      expect(textarea.classList.contains("error")).toBe(false);
+      expect(textarea.getAttribute("aria-invalid")).toBe("false");
+
+      const current = element.shadowRoot!.querySelector(".count-current")!;
+      expect(current.classList.contains("over")).toBe(false);
+    });
+
+    test("show-count がない場合は超過してもエラー表示にならない", async () => {
+      const { textarea } = await setup(
+        `<mi-text-area max-length="3" value="あいうえお"></mi-text-area>`,
+      );
+
+      // カウンターを出していない状態で理由の分からない赤枠を見せないため
+      expect(textarea.classList.contains("error")).toBe(false);
+      expect(textarea.getAttribute("aria-invalid")).toBe("false");
+    });
+  });
+
+  describe("フォームのリセット", () => {
+    const setupForm = async (attrs: string) => {
+      document.body.innerHTML = `
+        <form id="form">
+          <mi-text-area name="body" ${attrs}></mi-text-area>
+        </form>`;
+      await customElements.whenDefined("mi-text-area");
+      const element = document.querySelector("mi-text-area")!;
+      await element.updateComplete;
+      return {
+        element,
+        form: document.getElementById("form") as HTMLFormElement,
+      };
+    };
+
+    test("リセットすると初期値に戻る", async () => {
+      const { element, form } = await setupForm(`value="初期値"`);
+
+      element.value = "編集後のテキスト";
+      await element.updateComplete;
+
+      form.reset();
+      await element.updateComplete;
+
+      expect(element.value).toBe("初期値");
+      expect(element.shadowRoot!.querySelector("textarea")!.value).toBe(
+        "初期値",
+      );
+    });
+
+    test("リセット後の値がフォームの送信値にも反映される", async () => {
+      const { element, form } = await setupForm(`value="初期値"`);
+
+      element.value = "編集後のテキスト";
+      await element.updateComplete;
+
+      form.reset();
+      await element.updateComplete;
+
+      expect(new FormData(form).get("body")).toBe("初期値");
+    });
+
+    test("初期値がない場合は空に戻る", async () => {
+      const { element, form } = await setupForm("");
+
+      element.value = "編集後のテキスト";
+      await element.updateComplete;
+
+      form.reset();
+      await element.updateComplete;
+
+      expect(element.value).toBe("");
+    });
+  });
+
+  describe("ラベル", () => {
+    test("label を指定すると textarea に aria-label が設定される", async () => {
+      const { textarea } = await setup(
+        `<mi-text-area label="自己紹介"></mi-text-area>`,
+      );
+
+      expect(textarea.getAttribute("aria-label")).toBe("自己紹介");
+    });
+
+    test("label を指定しない場合は aria-label を出力しない", async () => {
+      // 空文字の aria-label はアクセシブルな名前を空にしてしまうため、属性自体を出さない
+      const { textarea } = await setup(`<mi-text-area></mi-text-area>`);
+
+      expect(textarea.hasAttribute("aria-label")).toBe(false);
+    });
+  });
+
+  describe("入力エリアの高さ", () => {
+    const heightOf = (textarea: HTMLTextAreaElement) =>
+      textarea.getBoundingClientRect().height;
+
+    test("min-rows を指定しない場合は2行分になる", async () => {
+      const { textarea } = await setup(`<mi-text-area></mi-text-area>`);
+
+      expect(textarea.rows).toBe(2);
+    });
+
+    test("medium の2行分の高さが Figma の指定値と一致する", async () => {
+      const { textarea } = await setup(`<mi-text-area></mi-text-area>`);
+
+      expect(heightOf(textarea)).toBe(58);
+    });
+
+    test("large の2行分の高さが Figma の指定値と一致する", async () => {
+      const { textarea } = await setup(
+        `<mi-text-area size="large"></mi-text-area>`,
+      );
+
+      expect(heightOf(textarea)).toBe(64);
+    });
+
+    test("min-rows を増やすと1行分ずつ高くなる", async () => {
+      // medium の1行は 21px（font-size 14px × line-height 1.5）
+      const { textarea } = await setup(
+        `<mi-text-area min-rows="3"></mi-text-area>`,
+      );
+
+      expect(heightOf(textarea)).toBe(58 + 21);
+    });
+
+    test("min-rows を指定するとその行数が下限になる", async () => {
+      const { textarea } = await setup(
+        `<mi-text-area min-rows="4"></mi-text-area>`,
+      );
+
+      expect(textarea.rows).toBe(4);
+      expect(textarea.style.getPropertyValue("--text-area-min-rows")).toBe("4");
+    });
+
+    test("min-rows に2未満を指定しても2として扱われる", async () => {
+      // デザイン仕様上 2 行が下限のため
+      const { element, textarea } = await setup(
+        `<mi-text-area min-rows="1"></mi-text-area>`,
+      );
+
+      expect(textarea.rows).toBe(2);
+      expect(textarea.style.getPropertyValue("--text-area-min-rows")).toBe("2");
+      // 見た目だけでなくプロパティ・属性も 2 に揃っていること
+      expect(element.minRows).toBe(2);
+      expect(element.getAttribute("min-rows")).toBe("2");
+    });
+
+    test("数値でない min-rows を指定しても2に正規化される", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area min-rows="あ"></mi-text-area>`,
+      );
+
+      expect(element.minRows).toBe(2);
+      expect(textarea.rows).toBe(2);
+    });
+
+    test("max-rows を指定しない場合は上限をかけない", async () => {
+      const { textarea } = await setup(`<mi-text-area></mi-text-area>`);
+
+      expect(textarea.hasAttribute("data-has-max-rows")).toBe(false);
+      expect(textarea.style.getPropertyValue("--text-area-max-rows")).toBe("");
+    });
+
+    test("max-rows を指定すると上限がかかる", async () => {
+      const { textarea } = await setup(
+        `<mi-text-area max-rows="6"></mi-text-area>`,
+      );
+
+      expect(textarea.hasAttribute("data-has-max-rows")).toBe(true);
+      expect(textarea.style.getPropertyValue("--text-area-max-rows")).toBe("6");
+    });
+
+    test("値のない max-rows は上限なしとして扱う", async () => {
+      // 属性値が空文字だと 0 になるため、そのままでは「一切伸びない」状態になってしまう
+      const { element, textarea } = await setup(
+        `<mi-text-area max-rows></mi-text-area>`,
+      );
+
+      expect(element.maxRows).toBe(null);
+      expect(textarea.hasAttribute("data-has-max-rows")).toBe(false);
+    });
+
+    test("max-rows に0以下を指定した場合も上限なしとして扱う", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area max-rows="0"></mi-text-area>`,
+      );
+
+      expect(element.maxRows).toBe(null);
+      expect(textarea.hasAttribute("data-has-max-rows")).toBe(false);
+    });
+
+    test("手動リサイズした高さが min-rows の変更で失われない", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area></mi-text-area>`,
+      );
+
+      // ブラウザが resize ドラッグで行うのと同じこと（インライン style に height を書く）
+      textarea.style.height = "200px";
+
+      element.minRows = 4;
+      await element.updateComplete;
+
+      expect(textarea.style.height).toBe("200px");
+      expect(textarea.style.getPropertyValue("--text-area-min-rows")).toBe("4");
+    });
+
+    test("max-rows が min-rows より小さい場合は min-rows に揃える", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area min-rows="5" max-rows="3"></mi-text-area>`,
+      );
+
+      expect(textarea.style.getPropertyValue("--text-area-max-rows")).toBe("5");
+      expect(element.maxRows).toBe(5);
+      expect(element.getAttribute("max-rows")).toBe("5");
+    });
+
+    test("入力量が増えると高さが伸びる", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area max-rows="10"></mi-text-area>`,
+      );
+      const initial = heightOf(textarea);
+
+      element.value = "1行目\n2行目\n3行目\n4行目\n5行目";
+      await element.updateComplete;
+
+      expect(heightOf(textarea)).toBeGreaterThan(initial);
+    });
+
+    test("min-rows と max-rows を同じ値にすると高さが固定される", async () => {
+      // 自動伸縮を止めたい場合の手段。JSDoc / Story に明記している挙動
+      const { element, textarea } = await setup(
+        `<mi-text-area min-rows="3" max-rows="3"></mi-text-area>`,
+      );
+      const initial = heightOf(textarea);
+
+      element.value = Array.from({ length: 20 }, (_, i) => `${i}行目`).join(
+        "\n",
+      );
+      await element.updateComplete;
+
+      expect(heightOf(textarea)).toBe(initial);
+      expect(textarea.scrollHeight).toBeGreaterThan(textarea.clientHeight);
+    });
+
+    test("flex コンテナの中でも潰れずコンテナ幅に追従する", async () => {
+      // field-sizing: content は幅の intrinsic size も内容ベースにするため、
+      // :host に inline-size がないと flex アイテムとして極端に細くなる
+      document.body.innerHTML = `<div style="display:flex; width:200px"><mi-text-area></mi-text-area></div>`;
+      await customElements.whenDefined("mi-text-area");
+      const element = document.querySelector("mi-text-area")!;
+      await element.updateComplete;
+
+      expect(Math.round(element.getBoundingClientRect().width)).toBe(200);
+    });
+
+    test("利用側の幅指定が :host の既定より優先される", async () => {
+      document.body.innerHTML = `<div style="display:flex; width:300px"><mi-text-area style="inline-size:120px"></mi-text-area></div>`;
+      await customElements.whenDefined("mi-text-area");
+      const element = document.querySelector("mi-text-area")!;
+      await element.updateComplete;
+
+      expect(Math.round(element.getBoundingClientRect().width)).toBe(120);
+    });
+
+    test("desktop では縦方向のリサイズができる", async () => {
+      const { textarea } = await setup(`<mi-text-area></mi-text-area>`);
+
+      expect(getComputedStyle(textarea).resize).toBe("vertical");
+    });
+
+    test("max-rows に達すると高さが止まる", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area max-rows="3"></mi-text-area>`,
+      );
+      const initial = heightOf(textarea);
+
+      element.value = Array.from({ length: 20 }, (_, i) => `${i}行目`).join(
+        "\n",
+      );
+      await element.updateComplete;
+      const capped = heightOf(textarea);
+
+      element.value = Array.from({ length: 40 }, (_, i) => `${i}行目`).join(
+        "\n",
+      );
+      await element.updateComplete;
+
+      // 上限まで伸びたうえで止まっていること（伸びずに止まっている状態と区別する）
+      expect(capped).toBeGreaterThan(initial);
+      // さらに入力しても高さは変わらず、中がスクロールする
+      expect(heightOf(textarea)).toBe(capped);
+      expect(textarea.scrollHeight).toBeGreaterThan(textarea.clientHeight);
+    });
+  });
+
+  describe("スマートフォン幅（720px 以下）", () => {
+    beforeEach(async () => {
+      await page.viewport(PHONE_WIDTH, VIEWPORT_HEIGHT);
+    });
+
+    test("2行分の高さがタッチ操作向けに大きくなる", async () => {
+      // font-size が 16px になるため1行が 24px になる
+      const { textarea } = await setup(`<mi-text-area></mi-text-area>`);
+
+      expect(textarea.getBoundingClientRect().height).toBe(64);
+    });
+
+    test("min-rows を増やすと phone 用の行の高さで増える", async () => {
+      const { textarea } = await setup(
+        `<mi-text-area min-rows="3"></mi-text-area>`,
+      );
+
+      expect(textarea.getBoundingClientRect().height).toBe(64 + 24);
+    });
+
+    test("リサイズハンドルを出さない", async () => {
+      const { textarea } = await setup(`<mi-text-area></mi-text-area>`);
+
+      expect(getComputedStyle(textarea).resize).toBe("none");
+    });
+  });
+
+  describe("autofocus", () => {
+    test("autofocus を指定すると textarea に反映される", async () => {
+      const { textarea } = await setup(
+        `<mi-text-area autofocus></mi-text-area>`,
+      );
+
+      expect(textarea.hasAttribute("autofocus")).toBe(true);
+    });
+
+    test("autofocus を指定しない場合は付かない", async () => {
+      const { textarea } = await setup(`<mi-text-area></mi-text-area>`);
+
+      expect(textarea.hasAttribute("autofocus")).toBe(false);
+    });
+  });
+
+  describe("required", () => {
+    test("required を指定すると textarea に aria-required=true が設定される", async () => {
+      const { textarea } = await setup(
+        `<mi-text-area required></mi-text-area>`,
+      );
+
+      expect(textarea.getAttribute("aria-required")).toBe("true");
+    });
+
+    test("required を指定しないと aria-required=false が設定される", async () => {
+      const { textarea } = await setup(`<mi-text-area></mi-text-area>`);
+
+      expect(textarea.getAttribute("aria-required")).toBe("false");
+    });
+
+    test("required を指定してもネイティブの required は付かない", async () => {
+      // ブラウザによる送信時バリデーションは行わない方針のため
+      const { textarea } = await setup(
+        `<mi-text-area required></mi-text-area>`,
+      );
+
+      expect(textarea.hasAttribute("required")).toBe(false);
+    });
+  });
+
+  describe("文字数の数え方", () => {
+    const countText = async (value: string) => {
+      const { element } = await setup(
+        `<mi-text-area show-count max-length="100" value="${value}"></mi-text-area>`,
+      );
+      return element.shadowRoot!.querySelector(".count-current")!.textContent;
+    };
+
+    test("絵文字は1文字として数えられる", async () => {
+      // String.length なら 2 になる
+      expect(await countText("\u{1F600}")).toBe("1");
+    });
+
+    test("絵文字と日本語が混在しても見た目どおりに数えられる", async () => {
+      // String.length なら 5 になる
+      expect(await countText("あ\u{1F600}い\u{1F600}")).toBe("4");
+    });
+
+    test("絵文字を含む場合も上限超過を判定できる", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area show-count max-length="2" value="\u{1F600}\u{1F600}\u{1F600}"></mi-text-area>`,
+      );
+
+      // コードポイントで3文字なので超過する（String.length だと 6 で誤判定）
+      const current = element.shadowRoot!.querySelector(".count-current")!;
+      expect(current.textContent).toBe("3");
+      expect(current.classList.contains("over")).toBe(true);
+      expect(textarea.getAttribute("aria-invalid")).toBe("true");
+    });
+
+    test("上限ちょうどの絵文字は超過にならない", async () => {
+      const { element } = await setup(
+        `<mi-text-area show-count max-length="2" value="\u{1F600}\u{1F600}"></mi-text-area>`,
+      );
+
+      const current = element.shadowRoot!.querySelector(".count-current")!;
+      expect(current.textContent).toBe("2");
+      expect(current.classList.contains("over")).toBe(false);
+    });
+
+    test("ZWJ で連結された絵文字は見た目どおりにならない（既知の制約）", async () => {
+      // 👨‍👩‍👧‍👦 は見た目1文字だが、コードポイントでは 7。
+      // 見た目と完全に一致させるには Intl.Segmenter（書記素）が必要なため、意図的に見送っている。
+      expect(
+        await countText(
+          "\u{1F468}\u200D\u{1F469}\u200D\u{1F467}\u200D\u{1F466}",
+        ),
+      ).toBe("7");
+    });
+  });
+
+  describe("文字数カウンターのスクリーンリーダー対応", () => {
+    const liveRegionOf = (element: Element) =>
+      element.shadowRoot!.querySelector('[role="status"]');
+
+    const input = async (element: MiTextArea, value: string) => {
+      const textarea = element.shadowRoot!.querySelector("textarea")!;
+      textarea.value = value;
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+      await element.updateComplete;
+    };
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    test("見た目のカウンターは aria-hidden で読み上げられない", async () => {
+      const { element } = await setup(
+        `<mi-text-area show-count max-length="10"></mi-text-area>`,
+      );
+
+      expect(
+        element
+          .shadowRoot!.querySelector(".count")!
+          .getAttribute("aria-hidden"),
+      ).toBe("true");
+    });
+
+    test("aria-describedby から上限の説明を参照する", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area show-count max-length="10"></mi-text-area>`,
+      );
+
+      const describedBy = textarea.getAttribute("aria-describedby")!;
+      expect(describedBy).toContain("count-description");
+
+      const description =
+        element.shadowRoot!.getElementById("count-description")!;
+      expect(description.textContent?.trim()).toBe("最大10文字入力できます");
+    });
+
+    test("入力直後は読み上げず、入力が止まってから残り文字数を通知する", async () => {
+      const { element } = await setup(
+        `<mi-text-area show-count max-length="10"></mi-text-area>`,
+      );
+
+      vi.useFakeTimers();
+      await input(element, "あいう");
+
+      // 入力のたびに読み上げるとキー入力を妨げるため、直後は空のまま
+      expect(liveRegionOf(element)!.textContent?.trim()).toBe("");
+
+      vi.advanceTimersByTime(1000);
+      await element.updateComplete;
+
+      expect(liveRegionOf(element)!.textContent?.trim()).toBe("あと7文字");
+    });
+
+    test("上限を超えた場合は超過文字数を通知する", async () => {
+      const { element } = await setup(
+        `<mi-text-area show-count max-length="3"></mi-text-area>`,
+      );
+
+      vi.useFakeTimers();
+      await input(element, "あいうえお");
+      vi.advanceTimersByTime(1000);
+      await element.updateComplete;
+
+      expect(liveRegionOf(element)!.textContent?.trim()).toBe("2文字オーバー");
+    });
+
+    test("連続入力では最後の状態だけが通知される", async () => {
+      const { element } = await setup(
+        `<mi-text-area show-count max-length="10"></mi-text-area>`,
+      );
+
+      vi.useFakeTimers();
+      await input(element, "あ");
+      vi.advanceTimersByTime(500);
+      await input(element, "あい");
+      vi.advanceTimersByTime(500);
+
+      // 1件目のタイマーは解除されているので、まだ何も通知されない
+      expect(liveRegionOf(element)!.textContent?.trim()).toBe("");
+
+      vi.advanceTimersByTime(500);
+      await element.updateComplete;
+
+      expect(liveRegionOf(element)!.textContent?.trim()).toBe("あと8文字");
+    });
+
+    test("show-count がない場合はライブリージョンも説明も持たない", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area max-length="10"></mi-text-area>`,
+      );
+
+      expect(liveRegionOf(element)).toBeNull();
+      expect(element.shadowRoot!.getElementById("description")).toBeNull();
+      expect(textarea.getAttribute("aria-describedby")).toBe("");
+    });
+  });
+
+  describe("description（読み上げ用の説明）", () => {
+    test("description を指定すると aria-describedby から参照される", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area description="500文字以内で入力してください"></mi-text-area>`,
+      );
+
+      const describedBy = textarea.getAttribute("aria-describedby")!;
+      expect(describedBy).toContain("description");
+
+      const description = element.shadowRoot!.getElementById("description")!;
+      expect(description.textContent?.trim()).toBe(
+        "500文字以内で入力してください",
+      );
+    });
+
+    test("description は視覚的には表示しない", async () => {
+      const { element } = await setup(
+        `<mi-text-area description="説明"></mi-text-area>`,
+      );
+
+      const description = element.shadowRoot!.getElementById("description")!;
+      expect(description.classList.contains("visually-hidden")).toBe(true);
+    });
+
+    test("description がない場合は要素も参照も作らない", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area></mi-text-area>`,
+      );
+
+      expect(element.shadowRoot!.getElementById("description")).toBeNull();
+      expect(textarea.getAttribute("aria-describedby")).toBe("");
+    });
+
+    test("description と文字数の説明は両方参照される", async () => {
+      const { textarea } = await setup(
+        `<mi-text-area description="説明" show-count max-length="10"></mi-text-area>`,
+      );
+
+      const ids = textarea.getAttribute("aria-describedby")!.split(" ");
+      expect(ids).toContain("description");
+      expect(ids).toContain("count-description");
+    });
+  });
+
+  describe("エラー表示", () => {
+    test('slot="error" の内容が mi-helper-text として表示される', async () => {
+      const { element } = await setup(`
+        <mi-text-area>
+          <span slot="error">エラーです</span>
+        </mi-text-area>
+      `);
+      await element.updateComplete;
+
+      const helperTexts =
+        element.shadowRoot!.querySelectorAll("mi-helper-text");
+      expect(helperTexts.length).toBe(1);
+      expect(helperTexts[0].textContent?.trim()).toBe("エラーです");
+      expect(helperTexts[0].getAttribute("status")).toBe("error");
+    });
+
+    test('slot="error" があると textarea に error クラスと aria-invalid が付く', async () => {
+      const { element, textarea } = await setup(`
+        <mi-text-area>
+          <span slot="error">エラーです</span>
+        </mi-text-area>
+      `);
+      await element.updateComplete;
+
+      expect(textarea.classList.contains("error")).toBe(true);
+      expect(textarea.getAttribute("aria-invalid")).toBe("true");
+      expect(textarea.getAttribute("aria-describedby")).toContain("error-0");
+    });
+
+    test("disabled の場合はエラーを表示しない", async () => {
+      const { element, textarea } = await setup(`
+        <mi-text-area disabled>
+          <span slot="error">エラーです</span>
+        </mi-text-area>
+      `);
+      await element.updateComplete;
+
+      expect(
+        element.shadowRoot!.querySelectorAll("mi-helper-text").length,
+      ).toBe(0);
+      expect(textarea.getAttribute("aria-invalid")).toBe("false");
+    });
+
+    test('後から追加した slot="error" が表示される', async () => {
+      const { element } = await setup(`<mi-text-area></mi-text-area>`);
+
+      const span = document.createElement("span");
+      span.slot = "error";
+      span.textContent = "後から追加したエラー";
+      element.appendChild(span);
+
+      // slotchange は非同期に飛ぶため、反映を待つ
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await element.updateComplete;
+
+      const helperTexts =
+        element.shadowRoot!.querySelectorAll("mi-helper-text");
+      expect(helperTexts.length).toBe(1);
+      expect(helperTexts[0].textContent?.trim()).toBe("後から追加したエラー");
+      expect(
+        element
+          .shadowRoot!.querySelector("textarea")!
+          .getAttribute("aria-invalid"),
+      ).toBe("true");
+    });
+
+    test("エラーがない場合は aria-invalid が false になる", async () => {
+      const { textarea } = await setup(`<mi-text-area></mi-text-area>`);
+
+      expect(textarea.getAttribute("aria-invalid")).toBe("false");
+    });
+  });
+
+  describe("イベント", () => {
+    test("input イベントがホスト要素の外まで届く", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area></mi-text-area>`,
+      );
+
+      const handler = vi.fn();
+      element.addEventListener("input", handler);
+
+      await page.elementLocator(textarea).fill("abc");
+
+      expect(handler).toHaveBeenCalled();
+    });
+
+    test("change イベントがホスト要素から発火し直される", async () => {
+      const { element, textarea } = await setup(
+        `<mi-text-area></mi-text-area>`,
+      );
+
+      const handler = vi.fn();
+      element.addEventListener("change", handler);
+
+      textarea.value = "abc";
+      textarea.dispatchEvent(new Event("change", { bubbles: true }));
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    test("change はネイティブの textarea と同じく bubbles: true / composed: false", async () => {
+      document.body.innerHTML = `<div id="ancestor"><mi-text-area></mi-text-area></div>`;
+      await customElements.whenDefined("mi-text-area");
+      const element = document.querySelector("mi-text-area")!;
+      await element.updateComplete;
+      const textarea = element.shadowRoot!.querySelector("textarea")!;
+
+      const received: Event[] = [];
+      element.addEventListener("change", (e) => received.push(e));
+      const onAncestor = vi.fn();
+      document
+        .getElementById("ancestor")!
+        .addEventListener("change", onAncestor);
+
+      textarea.dispatchEvent(new Event("change", { bubbles: true }));
+
+      expect(received[0].bubbles).toBe(true);
+      expect(received[0].composed).toBe(false);
+      // ネイティブの textarea と同じく、祖先要素でも拾える
+      expect(onAncestor).toHaveBeenCalledTimes(1);
+    });
+
+    test("change は外側の Shadow DOM を越えない（composed: false）", async () => {
+      const host = document.createElement("div");
+      document.body.replaceChildren(host);
+      const outerRoot = host.attachShadow({ mode: "open" });
+      outerRoot.innerHTML = `<mi-text-area></mi-text-area>`;
+      await customElements.whenDefined("mi-text-area");
+      const element = outerRoot.querySelector("mi-text-area")!;
+      await element.updateComplete;
+      const textarea = element.shadowRoot!.querySelector("textarea")!;
+
+      const onOutside = vi.fn();
+      document.addEventListener("change", onOutside);
+
+      try {
+        textarea.dispatchEvent(new Event("change", { bubbles: true }));
+
+        expect(onOutside).not.toHaveBeenCalled();
+      } finally {
+        document.removeEventListener("change", onOutside);
+      }
+    });
+  });
+
+  test("フォーカスすると内部の textarea にフォーカスが移る", async () => {
+    const { element, textarea } = await setup(`<mi-text-area></mi-text-area>`);
+
+    element.focus();
+
+    expect(element.shadowRoot!.activeElement).toBe(textarea);
+  });
+});

--- a/tests/text-area/normalize-rows.test.ts
+++ b/tests/text-area/normalize-rows.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+
+import { normalizeRows } from "../../src/components/text-area/mi-text-area";
+
+describe("normalizeRows", () => {
+  describe("最小行数", () => {
+    test("2 以上の指定はそのまま通る", () => {
+      expect(normalizeRows(4, null).minRows).toBe(4);
+    });
+
+    test("2 未満は 2 に切り上げる", () => {
+      // デザイン仕様上 2 行が下限
+      expect(normalizeRows(1, null).minRows).toBe(2);
+      expect(normalizeRows(0, null).minRows).toBe(2);
+      expect(normalizeRows(-3, null).minRows).toBe(2);
+    });
+
+    test("数値でない指定は 2 として扱う", () => {
+      // min-rows="abc" は NaN になる
+      expect(normalizeRows(Number.NaN, null).minRows).toBe(2);
+      expect(normalizeRows(Number.POSITIVE_INFINITY, null).minRows).toBe(2);
+    });
+
+    test("小数はそのまま通す", () => {
+      // CSS の calc でそのまま扱えるため、あえて切り捨てない
+      expect(normalizeRows(2.5, null).minRows).toBe(2.5);
+    });
+  });
+
+  describe("最大行数", () => {
+    test("未指定なら上限なしのまま", () => {
+      expect(normalizeRows(3, null).maxRows).toBe(null);
+    });
+
+    test("最小行数より大きい指定はそのまま通る", () => {
+      expect(normalizeRows(3, 8).maxRows).toBe(8);
+    });
+
+    test("最小行数と同じ指定も通る（高さを固定する用途）", () => {
+      expect(normalizeRows(3, 3).maxRows).toBe(3);
+    });
+
+    test("最小行数より小さい指定は最小行数に揃える", () => {
+      expect(normalizeRows(5, 3).maxRows).toBe(5);
+      // 切り上げ後の最小行数が基準になる
+      expect(normalizeRows(1, 1).maxRows).toBe(2);
+    });
+
+    test("0 以下は上限なしとして扱う", () => {
+      // max-rows（値なし）は空文字 → 0 になる。
+      // そのまま最小行数に揃えると「一切伸びない」状態が書き間違いで作られてしまう
+      expect(normalizeRows(3, 0).maxRows).toBe(null);
+      expect(normalizeRows(3, -1).maxRows).toBe(null);
+    });
+
+    test("数値でない指定は上限なしとして扱う", () => {
+      expect(normalizeRows(3, Number.NaN).maxRows).toBe(null);
+      expect(normalizeRows(3, Number.POSITIVE_INFINITY).maxRows).toBe(null);
+    });
+  });
+});


### PR DESCRIPTION
## 概要

複数行テキスト入力の `mi-text-area` と、ラベル付きの `mi-text-area-unit` を追加します。

あわせて、実装中に見つかった既存の不具合2件（`mi-label-unit` の `line-height` 未指定、`mi-button` 系テストの iframe 遷移）を修正しています。詳細は「レビュワーへの申し送り」を参照してください。

## 変更内容

### 新規コンポーネント

**`mi-text-area`**

- `value` / `placeholder` / `name` / `label` / `description` / `size`（medium・large）/ `disabled` / `required` / `autofocus`
- `min-rows`（既定2行）/ `max-rows` … 入力量に応じて高さが自動で伸びる。同値にすると高さを固定できる
- `max-length` / `show-count` … 文字数カウンター
- `slot="error"` … 複数のエラーメッセージ（HTML 構造を保持）

**`mi-text-area-unit`**

- `mi-label-unit` + `mi-text-area`。`text` / `support-text` / `required` を追加
- `text` を内側の `aria-label`、`support-text` を `description` に転送し、ラベル・補足テキストと入力欄をスクリーンリーダー上でも関連付ける

### 既存コンポーネントの修正

- **`mi-label-unit`**: `.label` / `.support` に `line-height` を明示（`fix`）
- **`mi-button` / `mi-icon-button` のテスト**: リンククリック時に `preventDefault` を追加（`test`）

### 主な設計判断

| 論点 | 決めたこと | 根拠 |
| --- | --- | --- |
| 文字数制限 | **ソフト**（超過を許容しカウンターを強調） | ネイティブ `maxlength` は貼り付けを黙って切り捨てる。GOV.UK / USWDS / SmartHR も同方式（いずれもソースで確認） |
| 文字数の数え方 | **コードポイント**（絵文字は1文字） | SmartHR と同じ。書記素（`Intl.Segmenter`）は**調べた範囲では**採用している DS が無く、tsconfig の lib 変更も伴うため見送り |
| 高さの自動伸縮 | CSS の `field-sizing: content` | JS の高さ計算が不要。下限 `min-rows`、上限 `max-rows` |
| `change` イベント | `bubbles: true` / `composed: false` | ネイティブの `<textarea>` と同じ値（実測で確認）。`mi-select-box` が `<select>` に合わせているのと同じ方針 |
| スクリーンリーダー | カウンターは `aria-hidden`、別途ライブリージョンで「あと○文字」を1秒デバウンスで通知 | 文字数カウンターを持つ DS（GOV.UK / USWDS / Carbon / SmartHR 等）はいずれも `aria-live` を併用していた |

### Figma との照合（全バリアント一致）

Figma のバリアントは入力エリアが3行分なので、**`min-rows="3"` を指定して比較**しています（実装のデフォルトは2行）。

| バリアント | Figma | 実装 |
| --- | --- | --- |
| desktop / medium | 108px | 108px |
| desktop / large（補足あり） | 137px | 137px |
| phone / medium | 117px | 117px |
| phone / large | 117px | 117px |

2行分の高さ（medium 58px / large 64px）、ラベルとの間隔 8px も一致しています。値はテストで固定しています。

## Test plan

- [x] `npm run lint`
- [x] `npm run format:prettier:check`
- [x] `npm run format:lint`
- [x] `npm run typecheck`
- [x] `npm run test`（**653件パス**。うち text-area 系 114件）
- [x] `npm run build`
- [x] CI green
- [x] Storybook で `AutoGrow` の伸び方・手動リサイズとの併用を確認
- [x] Storybook の Actions パネルに `change` が出ることを確認
- [x] Storybook で `mi-text-area-unit` の `WithSupportText` / `All` の見た目を確認
- [x] `mi-text-field-unit` の補足テキストの見た目を確認（下記の申し送り1）

## 変更の影響

- **見た目の変更: 有り**。`mi-label-unit` の修正により、**補足テキストの高さが 18px → 15.6px になります**（`mi-text-field-unit` にも影響。Figma に近づく方向）
- それ以外は新規コンポーネントの追加のみです
- `stories/text-field/` は Story の追加のみで、`src/components/text-field/` は1行も変更していません

## レビュワーへの申し送り

**1. `mi-label-unit` の `line-height` を修正しました（他コンポーネントに影響します）**

`.label` / `.support` に `line-height` の指定がなく `normal`（フォント依存）だったため、**OS によって高さが変わり**、Figma の指定値とも一致していませんでした。`typography.md` の line-height トークンに沿って明示しました。

- ラベル: 150%（14px × 1.5 = 21px。Figma 一致）
- 補足テキスト: 130%（12px × 1.3 = 15.6px。Figma の 16px 一致）

同ファイルの `.required` は既に `1.3` を持っており、指定漏れを揃える形です。

**`mi-text-field-unit` の補足テキストが 2px 低くなります。** Figma に近づく方向ですが、見た目の変更なので確認をお願いします。

なお、この不具合により `mi-text-area-unit` の寸法テストが **CI（Ubuntu）でのみ失敗**していました（macOS 108px / CI 105px）。ランナーのフォント構成は確認していませんが、`line-height: normal` がフォント依存であることが原因と考えられます。

**2. `mi-button` / `mi-icon-button` のテストを修正しました**

「リンクボタンをクリックすると click が1回だけ発火する」テストが、`href="https://example.com"` の `<a>` を `preventDefault` せずにクリックしていました。テスト用の iframe が外部サイトへ遷移し、Vitest が iframe との接続を失って**実行全体が中断**します。

**このコードは main にも存在していますが、main の CI は green です。** なぜこの PR で顕在化したのかは特定できていません（テストファイルが増えて iframe の実行順やタイミングが変わった / CI ランナーの負荷 / 単に条件を引いたか、のいずれか）。分かっているのは「`preventDefault` していないリンククリックが根本原因で、修正したら通った」までです。

`click` の発火回数を数えるテストで遷移の検証はしていないため、`preventDefault` を足しても検証内容は変わりません。まだ顕在化していない `mi-button` 側も予防的に直しています。

**3. デザイン仕様のうち「超過分の文字を error 色にする」は見送りました**

`textarea` の中身は DOM のテキストノードではなく `value` なので、文字の一部だけ色を変えられません（CSS Custom Highlight API も `textarea` には使えず、[w3c/csswg-drafts#9971](https://github.com/w3c/csswg-drafts/issues/9971) は2024年から未解決）。調べた範囲でこれを実現しているのは X（旧 Twitter）だけで、あちらは `contenteditable` の自作エディタです（textarea を使っている Mastodon、リッチエディタを使っている Bluesky はいずれも未実装）。超過は「赤枠 / カウンターの赤字 / スクリーンリーダーの読み上げ」の3経路で伝えています。

**この見送りは実装側の判断です。デザイナーへの共有はまだ行っていませんが、別途合意を進めます。**

**4. `field-sizing` のブラウザ対応**

Chrome / Edge 123+、Firefox 152+、Safari 26.2+（グローバル 83.95%）です。最新ブラウザのみをサポートする方針のため許容しています。非対応ブラウザでは宣言が無視され、`rows` 属性による固定高さになります（自動伸縮が効かないだけで表示は壊れません）。

**5. テストの viewport（別課題）**

`vitest.config.mts` に viewport の指定がなく、既定は 414px です。そのため 720px のメディアクエリを持つ **12ファイル（8〜9コンポーネント相当）がスマートフォン幅でのみテストされている**状態でした。この PR では text-area 系のテストファイル内で desktop / phone を明示的に切り替えています。全体設定の見直しは影響範囲が広いため別課題とさせてください。

## 参考リンク

- Figma（text-area）: https://www.figma.com/design/kHQNLM1dnk0EhZwOKBEBkL/Base-Component-Speeda-3.1-MITSUBACHI?node-id=182-4767
- Figma（text-area-unit）: https://www.figma.com/design/kHQNLM1dnk0EhZwOKBEBkL/Base-Component-Speeda-3.1-MITSUBACHI?node-id=7136-7463

🤖 Generated with [Claude Code](https://claude.com/claude-code)
